### PR TITLE
Increase Delay On Star Select

### DIFF
--- a/levels/menu/script.c
+++ b/levels/menu/script.c
@@ -88,7 +88,7 @@ const LevelScript level_main_menu_entry_2[] = {
     /*37*/ TRANSITION(/*transType*/ WARP_TRANSITION_FADE_INTO_COLOR, /*time*/ 16, /*color*/ 0xFF, 0xFF, 0xFF),
     /*39*/ SLEEP(/*frames*/ 16),
     /*40*/ CLEAR_LEVEL(),
-    /*41*/ SLEEP_BEFORE_EXIT(/*frames*/ 1),
+    /*41*/ SLEEP_BEFORE_EXIT(/*frames*/ 9),
     // L1:
     /*42*/ EXIT(),
 };


### PR DESCRIPTION
This is a simple one-line change that increases the delay between selecting a star and the level loading. Because the PC port basically removes all loading times, the "Let's-a-go" voice clip is cut off early, so this fixes that.

[increase_delay_on_star_select.zip](https://github.com/GateGuy/sm64pc/files/4997062/increase_delay_on_star_select.zip)

