### PR TITLE
Enable Special Triple Jump

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -1272,7 +1272,7 @@ s32 lvl_init_from_save_file(UNUSED s16 arg0, s32 levelNum) {
     gCurrCourseNum = COURSE_NONE;
     gSavedCourseNum = COURSE_NONE;
     gCurrCreditsEntry = NULL;
-    gSpecialTripleJump = 0;
+    gSpecialTripleJump = 1;
 
     init_mario_from_save_file();
     disable_warp_checkpoint();


### PR DESCRIPTION
This is a simple one-line change that enables the special triple jump you can get at the end of the game. Most people (myself included) prefer the normal triple jump, but it only took a couple minutes to find this, so why not.

[enable_special_triple_jump.zip](https://github.com/GateGuy/sm64pc/files/4997118/enable_special_triple_jump.zip)
