### PR TITLE
Stay In Level After Star (Permanent Version)

### DIFF
--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -763,6 +763,10 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
     u32 starIndex;
     u32 starGrabAction = ACT_STAR_DANCE_EXIT;
     u32 noExit = (o->oInteractionSubtype & INT_SUBTYPE_NO_EXIT) != 0;
+    u8 stayInLevelCommon = !(m->controller->buttonDown & L_TRIG || gCurrLevelNum == LEVEL_BOWSER_1 || gCurrLevelNum == LEVEL_BOWSER_2 || gCurrLevelNum == LEVEL_BOWSER_3);
+    if (stayInLevelCommon == TRUE) {
+        noExit = TRUE;
+    }
     u32 grandStar = (o->oInteractionSubtype & INT_SUBTYPE_GRAND_STAR) != 0;
 
     if (m->health >= 0x100) {
@@ -820,7 +824,11 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
             return set_mario_action(m, ACT_JUMBO_STAR_CUTSCENE, 0);
         }
 
-        return set_mario_action(m, starGrabAction, noExit + 2 * grandStar);
+        if (stayInLevelCommon == FALSE) {
+            return set_mario_action(m, starGrabAction, noExit + 2 * grandStar);
+        }
+        //If nonstop StayInLevel is enabled, autosave
+        save_file_do_save(gCurrSaveFileNum - 1);
     }
 
     return FALSE;

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -645,6 +645,11 @@ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
             set_mario_action(m, ACT_READING_AUTOMATIC_DIALOG, dialogID);
         } else {
             set_mario_action(m, isInWater ? ACT_WATER_IDLE : ACT_IDLE, 0);
+            set_fov_function(CAM_FOV_DEFAULT);
+            // fix camera bug when getting a star underwater with StayInLevel cheat enabled
+            if (isInWater) {
+                cutscene_exit_painting_end(m->area->camera);
+            }
         }
     }
 }


### PR DESCRIPTION
This makes you stay in a level after collecting a star. You can hold L while collecting a star to temporarily disable this effect and leave the level. This cheat has no effect on Bowser keys, or stars that already make you stay in the level in the base game.

There is also a [cheat version](https://github.com/GateGuy/sm64pc/pull/13) that can be turned on/off in-game, but it can cause merge conflicts due to the way cheats are added.

[nonstop_mode_always_enabled.zip](https://github.com/GateGuy/sm64pc/files/4997310/nonstop_mode_always_enabled.zip)