### PR TITLE
Draw Distance Setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ RENDER_API ?= GL
 WINDOW_API ?= SDL2
 # Audio backends: SDL1, SDL2
 AUDIO_API ?= SDL2
-# Controller backends (can have multiple, space separated): SDL2
+# Controller backends (can have multiple, space separated): SDL2, SDL1
 CONTROLLER_API ?= SDL2
 
 # Misc settings for EXTERNAL_DATA

--- a/Makefile
+++ b/Makefile
@@ -620,7 +620,7 @@ endif
 ASFLAGS := -I include -I $(BUILD_DIR) $(VERSION_ASFLAGS)
 
 ifeq ($(TARGET_WEB),1)
-LDFLAGS := -lm -lGL -lSDL2 -no-pie -s TOTAL_MEMORY=20MB -g4 --source-map-base http://localhost:8080/ -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']"
+  LDFLAGS := -lm -lGL -lSDL2 -no-pie -s TOTAL_MEMORY=64MB -g4 --source-map-base http://localhost:8080/ -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']"
 
 else ifeq ($(WINDOWS_BUILD),1)
   LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -Llib -lpthread $(BACKEND_LDFLAGS) -static

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ NO_LDIV ?= 0
 
 # Renderers: GL, GL_LEGACY, D3D11, D3D12
 RENDER_API ?= GL
-# Window managers: SDL2, DXGI (forced if D3D11 or D3D12 in RENDER_API)
+# Window managers: SDL1, SDL2, DXGI (forced if D3D11 or D3D12 in RENDER_API)
 WINDOW_API ?= SDL2
-# Audio backends: SDL2
+# Audio backends: SDL1, SDL2
 AUDIO_API ?= SDL2
 # Controller backends (can have multiple, space separated): SDL2
 CONTROLLER_API ?= SDL2
@@ -481,7 +481,9 @@ SDLCONFIG := $(CROSS)sdl2-config
 BACKEND_CFLAGS := -DRAPI_$(RENDER_API)=1 -DWAPI_$(WINDOW_API)=1 -DAAPI_$(AUDIO_API)=1
 # can have multiple controller APIs
 BACKEND_CFLAGS += $(foreach capi,$(CONTROLLER_API),-DCAPI_$(capi)=1)
-BACKEND_LDFLAGS :=
+BACKEND_LDFLAG0S :=
+
+SDL1_USED := 0
 SDL2_USED := 0
 
 # for now, it's either SDL+GL or DXGI+DirectX, so choose based on WAPI
@@ -492,7 +494,7 @@ ifeq ($(WINDOW_API),DXGI)
   endif
   BACKEND_LDFLAGS += -ld3dcompiler -ldxgi -ldxguid
   BACKEND_LDFLAGS += -lsetupapi -ldinput8 -luser32 -lgdi32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion -luuid -static
-else ifeq ($(WINDOW_API),SDL2)
+else ifeq ($(findstring SDL,$(WINDOW_API)),SDL)
   ifeq ($(WINDOWS_BUILD),1)
     BACKEND_LDFLAGS += -lglew32 -lglu32 -lopengl32
   else ifeq ($(TARGET_RPI),1)
@@ -502,20 +504,32 @@ else ifeq ($(WINDOW_API),SDL2)
   else
     BACKEND_LDFLAGS += -lGL
   endif
-  SDL_USED := 2
 endif
 
-ifeq ($(AUDIO_API),SDL2)
-  SDL_USED := 2
+ifneq (,$(findstring SDL2,$(AUDIO_API)$(WINDOW_API)$(CONTROLLER_API)))
+  SDL2_USED := 1
 endif
 
-ifneq (,$(findstring SDL,$(CONTROLLER_API)))
-  SDL_USED := 2
+ifneq (,$(findstring SDL1,$(AUDIO_API)$(WINDOW_API)$(CONTROLLER_API)))
+  SDL1_USED := 1
+endif
+
+ifeq ($(SDL1_USED)$(SDL2_USED),11)
+  $(error Cannot link both SDL1 and SDL2 at the same time)
 endif
 
 # SDL can be used by different systems, so we consolidate all of that shit into this
-ifeq ($(SDL_USED),2)
-  BACKEND_CFLAGS += -DHAVE_SDL2=1 `$(SDLCONFIG) --cflags`
+
+ifeq ($(SDL2_USED),1)
+  SDLCONFIG := $(CROSS)sdl2-config
+  BACKEND_CFLAGS += -DHAVE_SDL2=1
+else ifeq ($(SDL1_USED),1)
+  SDLCONFIG := $(CROSS)sdl-config
+  BACKEND_CFLAGS += -DHAVE_SDL1=1
+endif
+
+ifneq ($(SDL1_USED)$(SDL2_USED),00)
+  BACKEND_CFLAGS += `$(SDLCONFIG) --cflags`
   ifeq ($(WINDOWS_BUILD),1)
     BACKEND_LDFLAGS += `$(SDLCONFIG) --static-libs` -lsetupapi -luser32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion
   else

--- a/enhancements/60fps_ex.patch
+++ b/enhancements/60fps_ex.patch
@@ -112,7 +112,7 @@ index 802d97a..1b0d677 100644
  
  /** A node that allows an object to specify a different culling radius than the
 diff --git a/src/engine/surface_collision.c b/src/engine/surface_collision.c
-index 5b6775f..2c11e25 100644
+index 1da535b..49a5c03 100644
 --- a/src/engine/surface_collision.c
 +++ b/src/engine/surface_collision.c
 @@ -8,6 +8,7 @@
@@ -1890,19 +1890,10 @@ index 0467495..fa4eb33 100644
  
  using namespace Microsoft::WRL; // For ComPtr
 diff --git a/src/pc/gfx/gfx_sdl2.c b/src/pc/gfx/gfx_sdl2.c
-index 25c9f06..a6461ae 100644
+index 0108ca9..28d56ac 100644
 --- a/src/pc/gfx/gfx_sdl2.c
 +++ b/src/pc/gfx/gfx_sdl2.c
-@@ -53,7 +53,7 @@ static void (*kb_all_keys_up)(void) = NULL;
- // whether to use timer for frame control
- static bool use_timer = true;
- // time between consequtive game frames
--static const int frame_time = 1000 / FRAMERATE;
-+static const int frame_time = 1000 / (2 * FRAMERATE);
- 
- const SDL_Scancode windows_scancode_table[] = {
-   /*  0                        1                            2                         3                            4                     5                            6                            7  */
-@@ -142,7 +142,11 @@ static inline void gfx_sdl_set_vsync(const bool enabled) {
+@@ -150,7 +150,11 @@ static inline void gfx_sdl_set_vsync(const bool enabled) {
      if (enabled) {
          // try to detect refresh rate
          SDL_GL_SetSwapInterval(1);
@@ -1915,8 +1906,17 @@ index 25c9f06..a6461ae 100644
          if (vblanks) {
              printf("determined swap interval: %d\n", vblanks);
              SDL_GL_SetSwapInterval(vblanks);
+@@ -233,7 +237,7 @@ static void gfx_sdl_init(const char *window_title) {
+     gfx_sdl_set_fullscreen();
+ 
+     perf_freq = SDL_GetPerformanceFrequency();
+-    frame_time = perf_freq / FRAMERATE;
++    frame_time = perf_freq / (2 * FRAMERATE);
+ 
+     for (size_t i = 0; i < sizeof(windows_scancode_table) / sizeof(SDL_Scancode); i++) {
+         inverted_scancode_table[windows_scancode_table[i]] = i;
 diff --git a/src/pc/pc_main.c b/src/pc/pc_main.c
-index ed6ee74..63679ad 100644
+index 923e7ea..4fe6161 100644
 --- a/src/pc/pc_main.c
 +++ b/src/pc/pc_main.c
 @@ -83,6 +83,25 @@ void send_display_list(struct SPTask *spTask) {

--- a/enhancements/60fps_ex.patch
+++ b/enhancements/60fps_ex.patch
@@ -1906,7 +1906,7 @@ index 25c9f06..a6461ae 100644
      if (enabled) {
          // try to detect refresh rate
          SDL_GL_SetSwapInterval(1);
--        const int vblanks = test_vsync();
+-        const int vblanks = gCLIOpts.SyncFrames ? (int)gCLIOpts.SyncFrames : test_vsync();
 +        int vblanks = test_vsync();
 +        if (vblanks & 1)
 +            vblanks = 0; // not divisible by 60, fuck that

--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -14,7 +14,8 @@
 
 // Markers
 
-#define TEXT_OPT_HIGHLIGHT _("O")
+#define TEXT_OPT_L_HIGHLIGHT _(">")
+#define TEXT_OPT_R_HIGHLIGHT _("<")
 #define TEXT_OPT_UNBOUND   _("NONE")
 
 // Language specific strings

--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -56,6 +56,7 @@
 #define TEXT_OPT_AUTO      _("AUTO")
 #define TEXT_OPT_HUD       _("HUD")
 #define TEXT_OPT_THREEPT   _("THREE POINT")
+#define TEXT_OPT_DRAWDIST  _("DRAW DISTANCE")
 #define TEXT_OPT_APPLY     _("APPLY")
 #define TEXT_OPT_RESETWND  _("RESET WINDOW")
 
@@ -120,6 +121,7 @@
 #define TEXT_OPT_AUTO      _("Auto")
 #define TEXT_OPT_HUD       _("HUD")
 #define TEXT_OPT_THREEPT   _("Three-point")
+#define TEXT_OPT_DRAWDIST  _("Draw Distance")
 #define TEXT_OPT_APPLY     _("Apply")
 #define TEXT_OPT_RESETWND  _("Reset Window")
 

--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -13,6 +13,7 @@
 #include "game/object_list_processor.h"
 #include "graph_node.h"
 #include "surface_collision.h"
+#include "pc/configfile.h"
 
 // Macros for retrieving arguments from behavior scripts.
 #define BHV_CMD_GET_1ST_U8(index)  (u8)((gCurBhvCommand[index] >> 24) & 0xFF) // unused
@@ -999,7 +1000,7 @@ void cur_obj_update(void) {
         if (!(objFlags & OBJ_FLAG_ACTIVE_FROM_AFAR)) {
             // If the object has a render distance, check if it should be shown.
 #ifndef NODRAWINGDISTANCE
-            if (distanceFromMario > gCurrentObject->oDrawingDistance) {
+            if (distanceFromMario > gCurrentObject->oDrawingDistance * configDrawDistance / 100.0f) {
                 // Out of render distance, hide the object.
                 gCurrentObject->header.gfx.node.flags &= ~GRAPH_RENDER_ACTIVE;
                 gCurrentObject->activeFlags |= ACTIVE_FLAG_FAR_AWAY;

--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -13,7 +13,9 @@
 #include "game/object_list_processor.h"
 #include "graph_node.h"
 #include "surface_collision.h"
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // Macros for retrieving arguments from behavior scripts.
 #define BHV_CMD_GET_1ST_U8(index)  (u8)((gCurBhvCommand[index] >> 24) & 0xFF) // unused

--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -925,7 +925,7 @@ void find_surface_on_ray(Vec3f orig, Vec3f dir, struct Surface **hit_surface, Ve
 	}
 
     // increase collision checking precision (normally 1)
-    f32 precision = 3;
+    f32 precision = gCheckingSurfaceCollisionsForCamera ? 3 : 1;
 
     // Get cells we cross using DDA
     if (absx(dir[0]) >= absx(dir[2]))

--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -921,7 +921,7 @@ void find_surface_on_ray(Vec3f orig, Vec3f dir, struct Surface **hit_surface, Ve
 	}
 
     // increase collision checking precision (normally 1)
-    f32 precision = 2;
+    f32 precision = 5;
 
     // Get cells we cross using DDA
     if (absx(dir[0]) >= absx(dir[2]))

--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -851,7 +851,11 @@ void find_surface_on_ray_list(struct SurfaceNode *list, Vec3f orig, Vec3f dir, f
         // Reject surface if out of vertical bounds
         if (list->surface->lowerY > top || list->surface->upperY < bottom)
             continue;
-        
+
+        // Reject no-cam collision surfaces
+        if (gCheckingSurfaceCollisionsForCamera && (list->surface->flags & SURFACE_FLAG_NO_CAM_COLLISION))
+            continue;
+
         // Check intersection between the ray and this surface
         if ((hit = ray_surface_intersect(orig, dir, dir_length, list->surface, chk_hit_pos, &length)) != 0)
         {            
@@ -921,7 +925,7 @@ void find_surface_on_ray(Vec3f orig, Vec3f dir, struct Surface **hit_surface, Ve
 	}
 
     // increase collision checking precision (normally 1)
-    f32 precision = 5;
+    f32 precision = 3;
 
     // Get cells we cross using DDA
     if (absx(dir[0]) >= absx(dir[2]))

--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -919,13 +919,16 @@ void find_surface_on_ray(Vec3f orig, Vec3f dir, struct Surface **hit_surface, Ve
 		find_surface_on_ray_cell(cellX, cellZ, orig, normalized_dir, dir_length, hit_surface, hit_pos, &max_length);
 		return;
 	}
-    
+
+    // increase collision checking precision (normally 1)
+    f32 precision = 2;
+
     // Get cells we cross using DDA
     if (absx(dir[0]) >= absx(dir[2]))
-        step = absx(dir[0]) / CELL_SIZE;
+        step = precision * absx(dir[0]) / CELL_SIZE;
     else
-        step = absx(dir[2]) / CELL_SIZE;
-    
+        step = precision * absx(dir[2]) / CELL_SIZE;
+
     dx = dir[0] / step / CELL_SIZE;
     dz = dir[2] / step / CELL_SIZE;
     

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -14,6 +14,7 @@
 #include "game/mario.h"
 #include "game/object_list_processor.h"
 #include "surface_load.h"
+#include "pc/configfile.h"
 
 s32 unused8038BE90;
 
@@ -786,7 +787,7 @@ void load_object_collision_model(void) {
     }
 
 #ifndef NODRAWINGDISTANCE
-    if (marioDist < gCurrentObject->oDrawingDistance) {
+    if (marioDist < gCurrentObject->oDrawingDistance * configDrawDistance / 100.0f) {
 #endif
         gCurrentObject->header.gfx.node.flags |= GRAPH_RENDER_ACTIVE;
 #ifndef NODRAWINGDISTANCE

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -596,6 +596,7 @@ void load_area_terrain(s16 index, s16 *data, s8 *surfaceRooms, s16 *macroObjects
     gSurfaceNodesAllocated = 0;
     gSurfacesAllocated = 0;
 
+    clear_dynamic_surfaces();
     clear_static_surfaces();
 
     // A while loop iterating through each section of the level data. Sections of data

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -14,7 +14,9 @@
 #include "game/mario.h"
 #include "game/object_list_processor.h"
 #include "surface_load.h"
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 s32 unused8038BE90;
 

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -596,7 +596,6 @@ void load_area_terrain(s16 index, s16 *data, s8 *surfaceRooms, s16 *macroObjects
     gSurfaceNodesAllocated = 0;
     gSurfacesAllocated = 0;
 
-    clear_dynamic_surfaces();
     clear_static_surfaces();
 
     // A while loop iterating through each section of the level data. Sections of data

--- a/src/game/behaviors/bub.inc.c
+++ b/src/game/behaviors/bub.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // bub.c.inc
 
 // NOTE: These first set of functions spawn a school of bub depending on objF4's
@@ -9,7 +11,7 @@ void bub_spawner_act_0(void) {
     s32 i;
     s32 sp18 = o->oBirdChirpChirpUnkF4;
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 1500.0f) {
+    if (o->oDistanceToMario < 15 * configDrawDistance) {
 #endif
         for (i = 0; i < sp18; i++)
             spawn_object(o, MODEL_BUB, bhvBub);

--- a/src/game/behaviors/bub.inc.c
+++ b/src/game/behaviors/bub.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // bub.c.inc
 

--- a/src/game/behaviors/chain_chomp.inc.c
+++ b/src/game/behaviors/chain_chomp.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/chain_chomp.inc.c
+++ b/src/game/behaviors/chain_chomp.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvChainChomp, bhvChainChompChainPart, bhvWoodenPost, and bhvChainChompGate.
@@ -54,7 +56,7 @@ static void chain_chomp_act_uninitialized(void) {
     s32 i;
 
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 3000.0f) {
+    if (o->oDistanceToMario < 30 * configDrawDistance) {
 #endif
         segments = mem_pool_alloc(gObjectMemoryPool, 5 * sizeof(struct ChainSegment));
         if (segments != NULL) {
@@ -364,7 +366,7 @@ static void chain_chomp_act_move(void) {
 
     // Unload chain if mario is far enough
 #ifndef NODRAWINGDISTANCE
-    if (o->oChainChompReleaseStatus == CHAIN_CHOMP_NOT_RELEASED && o->oDistanceToMario > 4000.0f) {
+    if (o->oChainChompReleaseStatus == CHAIN_CHOMP_NOT_RELEASED && o->oDistanceToMario > 40 * configDrawDistance) {
         o->oAction = CHAIN_CHOMP_ACT_UNLOAD_CHAIN;
         o->oForwardVel = o->oVelY = 0.0f;
     } else {

--- a/src/game/behaviors/checkerboard_platform.inc.c
+++ b/src/game/behaviors/checkerboard_platform.inc.c
@@ -4,6 +4,14 @@ struct Struct8032F754 D_8032F754[] = { { 145, { 0.7f, 1.5f, 0.7f }, 7.0f },
                                        { 235, { 1.2f, 2.0f, 1.2f }, 11.6f } };
 
 void bhv_checkerboard_elevator_group_init(void) {
+    // Added to prevent a crash in the vanish cap stage
+    cur_obj_hide();
+    // Here's the theory: Since it is only valid for a few frames, I believe
+    // the model gets deallocated after removal. Since changing the camera
+    // precision makes the camera end up in a slightly different spot, it
+    // could be trying to render the object when `precision` is set to 3 but
+    // not to 1.
+
     s32 sp3C;
     s32 sp38;
     s32 sp34;

--- a/src/game/behaviors/cloud.inc.c
+++ b/src/game/behaviors/cloud.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvCloud and bhvCloudPart.
@@ -48,7 +50,7 @@ static void cloud_act_spawn_parts(void) {
  */
 static void cloud_act_fwoosh_hidden(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         cur_obj_unhide();
         o->oAction = CLOUD_ACT_SPAWN_PARTS;
@@ -63,7 +65,7 @@ static void cloud_act_fwoosh_hidden(void) {
  */
 static void cloud_fwoosh_update(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 2500.0f) {
+    if (o->oDistanceToMario > 25 * configDrawDistance) {
         o->oAction = CLOUD_ACT_UNLOAD;
     } else {
 #endif

--- a/src/game/behaviors/cloud.inc.c
+++ b/src/game/behaviors/cloud.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/coin.inc.c
+++ b/src/game/behaviors/coin.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // coin.c.inc
 

--- a/src/game/behaviors/coin.inc.c
+++ b/src/game/behaviors/coin.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // coin.c.inc
 
 struct ObjectHitbox sYellowCoinHitbox = {
@@ -185,7 +187,7 @@ void bhv_coin_formation_loop(void) {
     switch (o->oAction) {
         case 0:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario < 2000.0f) {
+            if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
                 for (bitIndex = 0; bitIndex < 8; bitIndex++) {
                     if (!(o->oCoinUnkF4 & (1 << bitIndex)))
@@ -198,7 +200,7 @@ void bhv_coin_formation_loop(void) {
             break;
         case 1:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario > 2100.0f)
+            if (o->oDistanceToMario > 21 * configDrawDistance)
                 o->oAction++;
 #endif
             break;

--- a/src/game/behaviors/enemy_lakitu.inc.c
+++ b/src/game/behaviors/enemy_lakitu.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/enemy_lakitu.inc.c
+++ b/src/game/behaviors/enemy_lakitu.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvEnemyLakitu.
@@ -25,7 +27,7 @@ static struct ObjectHitbox sEnemyLakituHitbox = {
  */
 static void enemy_lakitu_act_uninitialized(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         spawn_object_relative_with_scale(CLOUD_BP_LAKITU_CLOUD, 0, 0, 0, 2.0f, o, MODEL_MIST, bhvCloud);
 

--- a/src/game/behaviors/fish.inc.c
+++ b/src/game/behaviors/fish.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 /**
  * @file fish.inc.c
@@ -21,22 +23,22 @@ void fish_act_spawn(void) {
         
         // Blue fish with a quanitiy of twenty.
         case 0:
-            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Blue fish with a quanitiy of five.
         case 1:
-            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Cyan fish with a quanitiy of twenty.
         case 2:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
             
         // Cyan fish with a quanitiy of five.
         case 3:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
     }
     /**
@@ -45,7 +47,7 @@ void fish_act_spawn(void) {
      * Fish moves at random with a max-range of 700.0f.
      */
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < minDistToMario || gCurrLevelNum == LEVEL_SA) {
+    if (o->oDistanceToMario < minDistToMario * configDrawDistance / 100 || gCurrLevelNum == LEVEL_SA) {
 #endif
         for (i = 0; i < schoolQuantity; i++) {
             fishObject = spawn_object(o, model, bhvFish);

--- a/src/game/behaviors/fish.inc.c
+++ b/src/game/behaviors/fish.inc.c
@@ -23,22 +23,22 @@ void fish_act_spawn(void) {
         
         // Blue fish with a quanitiy of twenty.
         case 0:
-            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Blue fish with a quanitiy of five.
         case 1:
-            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Cyan fish with a quanitiy of twenty.
         case 2:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
             
         // Cyan fish with a quanitiy of five.
         case 3:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
     }
     /**

--- a/src/game/behaviors/fish.inc.c
+++ b/src/game/behaviors/fish.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 /**
  * @file fish.inc.c
  * Implements behaviour and spawning for fish located in the Secret Aquarium and other levels.
@@ -19,22 +21,22 @@ void fish_act_spawn(void) {
         
         // Blue fish with a quanitiy of twenty.
         case 0:
-            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Blue fish with a quanitiy of five.
         case 1:
-            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Cyan fish with a quanitiy of twenty.
         case 2:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
             
         // Cyan fish with a quanitiy of five.
         case 3:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
     }
     /**
@@ -64,7 +66,7 @@ void fish_act_spawn(void) {
 void fish_act_respawn(void) {
 #ifndef NODRAWINGDISTANCE
     if (gCurrLevelNum != LEVEL_SA) {
-        if (gMarioObject->oPosY - o->oPosY > 2000.0f) {
+        if (gMarioObject->oPosY - o->oPosY > 20 * configDrawDistance) {
             o->oAction = FISH_ACT_RESPAWN;
         }
     }

--- a/src/game/behaviors/goomba.inc.c
+++ b/src/game/behaviors/goomba.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/goomba.inc.c
+++ b/src/game/behaviors/goomba.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvGoomba and bhvGoombaTripletSpawner,
@@ -79,7 +81,7 @@ void bhv_goomba_triplet_spawner_update(void) {
     // spawn them
     if (o->oAction == GOOMBA_TRIPLET_SPAWNER_ACT_UNLOADED) {
 #ifndef NODRAWINGDISTANCE
-        if (o->oDistanceToMario < 3000.0f) {
+        if (o->oDistanceToMario < 30 * configDrawDistance) {
 #endif
             // The spawner is capable of spawning more than 3 goombas, but this
             // is not used in the game
@@ -102,7 +104,7 @@ void bhv_goomba_triplet_spawner_update(void) {
             o->oAction += 1;
 #ifndef NODRAWINGDISTANCE
         }
-    } else if (o->oDistanceToMario > 4000.0f) {
+    } else if (o->oDistanceToMario > 40 * configDrawDistance) {
         // If mario is too far away, enter the unloaded action. The goombas
         // will detect this and unload themselves
         o->oAction = GOOMBA_TRIPLET_SPAWNER_ACT_UNLOADED;

--- a/src/game/behaviors/heave_ho.inc.c
+++ b/src/game/behaviors/heave_ho.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // heave_ho.c.inc
 
 s16 D_8032F460[][2] = { { 30, 0 }, { 42, 1 }, { 52, 0 },  { 64, 1 },  { 74, 0 },
@@ -73,7 +75,7 @@ void heave_ho_act_3(void) {
 
 void heave_ho_act_0(void) {
 #ifndef NODRAWINGDISTANCE
-    if (find_water_level(o->oPosX, o->oPosZ) < o->oPosY && o->oDistanceToMario < 4000.0f) {
+    if (find_water_level(o->oPosX, o->oPosZ) < o->oPosY && o->oDistanceToMario < 40 * configDrawDistance) {
 #else
     if (find_water_level(o->oPosX, o->oPosZ) < (o->oPosY - 50.0f)) {
 #endif

--- a/src/game/behaviors/heave_ho.inc.c
+++ b/src/game/behaviors/heave_ho.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // heave_ho.c.inc
 

--- a/src/game/behaviors/king_bobomb.inc.c
+++ b/src/game/behaviors/king_bobomb.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // king_bobomb.c.inc
 

--- a/src/game/behaviors/king_bobomb.inc.c
+++ b/src/game/behaviors/king_bobomb.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // king_bobomb.c.inc
 
 // Copy of geo_update_projectile_pos_from_parent
@@ -296,7 +298,7 @@ void king_bobomb_move(void) {
     cur_obj_call_action_function(sKingBobombActions);
     exec_anim_sound_state(sKingBobombSoundStates);
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 5000.0f)
+    if (o->oDistanceToMario < 50 * configDrawDistance)
 #endif
         cur_obj_enable_rendering();
 #ifndef NODRAWINGDISTANCE

--- a/src/game/behaviors/lll_floating_wood_piece.inc.c
+++ b/src/game/behaviors/lll_floating_wood_piece.inc.c
@@ -1,5 +1,7 @@
 // lll_floating_wood_piece.c.inc
 
+#include "pc/configfile.h"
+
 void bhv_lll_wood_piece_loop(void) {
     if (o->oTimer == 0)
         o->oPosY -= 100.0f;
@@ -15,7 +17,7 @@ void bhv_lll_floating_wood_bridge_loop(void) {
     switch (o->oAction) {
         case 0:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario < 2500.0f) {
+            if (o->oDistanceToMario < 25 * configDrawDistance) {
 #endif
                 for (i = 1; i < 4; i++) {
                     sp3C = spawn_object_relative(0, (i - 2) * 300, 0, 0, o, MODEL_LLL_WOOD_BRIDGE,
@@ -29,7 +31,7 @@ void bhv_lll_floating_wood_bridge_loop(void) {
             break;
         case 1:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario > 2600.0f)
+            if (o->oDistanceToMario > 26 * configDrawDistance)
                 o->oAction = 2;
 #endif
             break;

--- a/src/game/behaviors/lll_floating_wood_piece.inc.c
+++ b/src/game/behaviors/lll_floating_wood_piece.inc.c
@@ -1,6 +1,8 @@
 // lll_floating_wood_piece.c.inc
 
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 void bhv_lll_wood_piece_loop(void) {
     if (o->oTimer == 0)

--- a/src/game/behaviors/lll_rotating_hex_flame.inc.c
+++ b/src/game/behaviors/lll_rotating_hex_flame.inc.c
@@ -1,6 +1,8 @@
 // lll_rotating_hex_flame.c.inc
 
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 void bhv_lll_rotating_hex_flame_loop(void) {
     f32 sp24 = o->oLllRotatingHexFlameUnkF4;

--- a/src/game/behaviors/lll_rotating_hex_flame.inc.c
+++ b/src/game/behaviors/lll_rotating_hex_flame.inc.c
@@ -1,5 +1,7 @@
 // lll_rotating_hex_flame.c.inc
 
+#include "pc/configfile.h"
+
 void bhv_lll_rotating_hex_flame_loop(void) {
     f32 sp24 = o->oLllRotatingHexFlameUnkF4;
     f32 sp20 = o->oLllRotatingHexFlameUnkF8;
@@ -31,7 +33,7 @@ void fire_bar_spawn_flames(s16 a0) {
 
 void fire_bar_act_0(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 3000.0f)
+    if (o->oDistanceToMario < 30 * configDrawDistance)
 #endif
         o->oAction = 1;
 }
@@ -48,7 +50,7 @@ void fire_bar_act_2(void) {
     o->oAngleVelYaw = -0x100;
     o->oMoveAngleYaw += o->oAngleVelYaw;
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 3200.0f)
+    if (o->oDistanceToMario > 32 * configDrawDistance)
         o->oAction = 3;
 #endif
 }

--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 /**
  * Behavior for bhvPiranhaPlant.
  * This controls Piranha Plants, which alternate between sleeping, attacking,
@@ -331,7 +333,7 @@ void bhv_piranha_plant_loop(void) {
     #ifndef NODRAWINGDISTANCE
     // In WF, hide all Piranha Plants once high enough up.
     if (gCurrLevelNum == LEVEL_WF) {
-        if (gMarioObject->oPosY > 3400.0f)
+        if (gMarioObject->oPosY > 34 * configDrawDistance)
             cur_obj_hide();
         else
             cur_obj_unhide();

--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 /**
  * Behavior for bhvPiranhaPlant.

--- a/src/game/behaviors/pokey.inc.c
+++ b/src/game/behaviors/pokey.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/pokey.inc.c
+++ b/src/game/behaviors/pokey.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvPokey and bhvPokeyBodyPart.
@@ -152,7 +154,7 @@ static void pokey_act_uninitialized(void) {
     s16 partModel;
 
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         partModel = MODEL_POKEY_HEAD;
 
@@ -190,7 +192,7 @@ static void pokey_act_wander(void) {
     if (o->oPokeyNumAliveBodyParts == 0) {
         obj_mark_for_deletion(o);
 #ifndef NODRAWINGDISTANCE
-    } else if (o->oDistanceToMario > 2500.0f) {
+    } else if (o->oDistanceToMario > 25 * configDrawDistance) {
         o->oAction = POKEY_ACT_UNLOAD_PARTS;
         o->oForwardVel = 0.0f;
 #endif

--- a/src/game/behaviors/sl_walking_penguin.inc.c
+++ b/src/game/behaviors/sl_walking_penguin.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // sl_walking_penguin.c.inc
 
 struct SLWalkingPenguinStep {
@@ -98,7 +100,7 @@ void bhv_sl_walking_penguin_loop(void) {
     
     cur_obj_move_standard(-78);
 #ifndef NODRAWINGDISTANCE
-     if (!cur_obj_hide_if_mario_far_away_y(1000.0f))
+     if (!cur_obj_hide_if_mario_far_away_y(10 * configDrawDistance))
 #endif
         play_penguin_walking_sound(PENGUIN_WALK_BIG);
     

--- a/src/game/behaviors/sl_walking_penguin.inc.c
+++ b/src/game/behaviors/sl_walking_penguin.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // sl_walking_penguin.c.inc
 

--- a/src/game/behaviors/snufit.inc.c
+++ b/src/game/behaviors/snufit.inc.c
@@ -181,10 +181,9 @@ void bhv_snufit_balls_loop(void) {
     // If far from Mario or in a different room, despawn.
     if ((o->activeFlags & ACTIVE_FLAG_IN_DIFFERENT_ROOM)
 #ifndef NODRAWINGDISTANCE
-        || (o->oTimer != 0 && o->oDistanceToMario > 1500.0f)) {
-#else
-        || (o->oTimer != 0)) {
+        || (o->oTimer != 0 && o->oDistanceToMario > 1500.0f)
 #endif
+            ){
         obj_mark_for_deletion(o);
     }
 

--- a/src/game/behaviors/snufit.inc.c
+++ b/src/game/behaviors/snufit.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 /**
  * Behavior file for bhvSnufit and bhvSnufitBalls.
  * Snufits are present in HMC and CotMC, and are the fly guy
@@ -181,7 +183,7 @@ void bhv_snufit_balls_loop(void) {
     // If far from Mario or in a different room, despawn.
     if ((o->activeFlags & ACTIVE_FLAG_IN_DIFFERENT_ROOM)
 #ifndef NODRAWINGDISTANCE
-        || (o->oTimer != 0 && o->oDistanceToMario > 1500.0f)
+        || (o->oTimer != 0 && o->oDistanceToMario > 15 * configDrawDistance)
 #endif
             ){
         obj_mark_for_deletion(o);

--- a/src/game/behaviors/snufit.inc.c
+++ b/src/game/behaviors/snufit.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 /**
  * Behavior file for bhvSnufit and bhvSnufitBalls.

--- a/src/game/behaviors/triplet_butterfly.inc.c
+++ b/src/game/behaviors/triplet_butterfly.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 struct TripletButterflyActivationData {
     s32 model;
     const BehaviorScript *behavior;
@@ -55,7 +57,7 @@ static void triplet_butterfly_act_init(void) {
 
 static void triplet_butterfly_act_wander(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 1500.0f) {
+    if (o->oDistanceToMario > 15 * configDrawDistance) {
         obj_mark_for_deletion(o);
     } else {
 #endif

--- a/src/game/behaviors/triplet_butterfly.inc.c
+++ b/src/game/behaviors/triplet_butterfly.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 struct TripletButterflyActivationData {
     s32 model;

--- a/src/game/behaviors/water_bomb_cannon.inc.c
+++ b/src/game/behaviors/water_bomb_cannon.inc.c
@@ -1,5 +1,7 @@
 // water_bomb_cannon.inc.c
 
+#include "pc/configfile.h"
+
 void bhv_bubble_cannon_barrel_loop(void) {
     struct Object *val04;
 
@@ -39,7 +41,7 @@ void bhv_bubble_cannon_barrel_loop(void) {
 
 void water_bomb_cannon_act_0(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         spawn_object(o, MODEL_CANNON_BARREL, bhvCannonBarrelBubbles);
         cur_obj_unhide();
@@ -53,7 +55,7 @@ void water_bomb_cannon_act_0(void) {
 
 void water_bomb_cannon_act_1(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 2500.0f) {
+    if (o->oDistanceToMario > 25 * configDrawDistance) {
         o->oAction = 2;
     } else if (o->oBehParams2ndByte == 0) {
 #else

--- a/src/game/behaviors/water_bomb_cannon.inc.c
+++ b/src/game/behaviors/water_bomb_cannon.inc.c
@@ -1,6 +1,8 @@
 // water_bomb_cannon.inc.c
 
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 void bhv_bubble_cannon_barrel_loop(void) {
     struct Object *val04;

--- a/src/game/behaviors/whirlpool.inc.c
+++ b/src/game/behaviors/whirlpool.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // whirlpool.c.inc
 
 static struct ObjectHitbox sWhirlpoolHitbox = {
@@ -36,7 +38,7 @@ void whirpool_orient_graph(void) {
 
 void bhv_whirlpool_loop(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 5000.0f) {
+    if (o->oDistanceToMario < 50 * configDrawDistance) {
 #endif
         o->header.gfx.node.flags &= ~GRAPH_RENDER_INVISIBLE;
 

--- a/src/game/behaviors/whirlpool.inc.c
+++ b/src/game/behaviors/whirlpool.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // whirlpool.c.inc
 

--- a/src/game/behaviors/whomp.inc.c
+++ b/src/game/behaviors/whomp.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // whomp.c.inc
 

--- a/src/game/behaviors/whomp.inc.c
+++ b/src/game/behaviors/whomp.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // whomp.c.inc
 
 void whomp_play_sfx_from_pound_animation(void) {
@@ -250,9 +252,9 @@ void bhv_whomp_loop(void) {
         // o->oBehParams2ndByte here seems to be a flag
         // indicating whether this is a normal or king whomp
         if (o->oBehParams2ndByte != 0)
-            cur_obj_hide_if_mario_far_away_y(2000.0f);
+            cur_obj_hide_if_mario_far_away_y(20 * configDrawDistance);
         else
-            cur_obj_hide_if_mario_far_away_y(1000.0f);
+            cur_obj_hide_if_mario_far_away_y(10 * configDrawDistance);
 #endif
         load_object_collision_model();
     }

--- a/src/game/bettercamera.inc.h
+++ b/src/game/bettercamera.inc.h
@@ -16,6 +16,9 @@
 #include <stdio.h>
 #endif
 
+#define NEW_CAM_BOUNDING_BOX_RAYS 4
+#define NEW_CAM_BOUNDING_BOX_HRADIUS 250
+#define NEW_CAM_BOUNDING_BOX_VRADIUS 50
 
 /**
 Quick explanation of the camera modes
@@ -473,6 +476,47 @@ static void newcam_update_values(void) {
     }
 }
 
+static void newcam_bounding_box(void) {
+    Vec3f camdirs[NEW_CAM_BOUNDING_BOX_RAYS] = { 0 };
+    Vec3f raypos[NEW_CAM_BOUNDING_BOX_RAYS] = { 0 };
+    s16 antiYaw = newcam_yaw - 0x4000;
+
+    // sideways ray 1
+    camdirs[0][0] = coss(antiYaw) * NEW_CAM_BOUNDING_BOX_HRADIUS;
+    camdirs[0][2] = sins(antiYaw) * NEW_CAM_BOUNDING_BOX_HRADIUS;
+
+    // sideways ray 2
+    camdirs[1][0] = -coss(antiYaw) * NEW_CAM_BOUNDING_BOX_HRADIUS;
+    camdirs[1][2] = -sins(antiYaw) * NEW_CAM_BOUNDING_BOX_HRADIUS;
+
+    // vertical rays
+    camdirs[2][1] = -NEW_CAM_BOUNDING_BOX_VRADIUS;
+    camdirs[3][1] =  NEW_CAM_BOUNDING_BOX_VRADIUS;
+
+    for (int i = 0; i < NEW_CAM_BOUNDING_BOX_RAYS; i++) {
+        struct Surface* surf;
+        Vec3f offset = { 0 };
+
+        Vec3f startpos = { 0 };
+        vec3f_copy(startpos, newcam_pos);
+        vec3f_add(startpos, offset);
+
+        find_surface_on_ray(startpos, camdirs[i], &surf, raypos[i]);
+        if (!surf) {
+            vec3f_copy(raypos[i], startpos);
+            vec3f_add(raypos[i], camdirs[i]);
+        }
+    }
+
+    Vec3f avg = { 0 };
+    for (int i = 0; i < NEW_CAM_BOUNDING_BOX_RAYS; i++) {
+        vec3f_add(avg, raypos[i]);
+    }
+    vec3f_mul(avg, 1.0f / ((f32)NEW_CAM_BOUNDING_BOX_RAYS));
+
+    vec3f_copy(newcam_pos, avg);
+}
+
 static void newcam_collision(void) {
     struct Surface *surf;
     Vec3f camdir;
@@ -486,8 +530,16 @@ static void newcam_collision(void) {
     newcam_coldist = sqrtf((newcam_pos_target[0] - hitpos[0]) * (newcam_pos_target[0] - hitpos[0]) + (newcam_pos_target[1] - hitpos[1]) * (newcam_pos_target[1] - hitpos[1]) + (newcam_pos_target[2] - hitpos[2]) * (newcam_pos_target[2] - hitpos[2]));
 
     if (surf) {
+        // offset the hit pos by the hit normal
+        Vec3f offset = { 0 };
+        offset[0] = surf->normal.x;
+        offset[1] = surf->normal.y;
+        offset[2] = surf->normal.z;
+        vec3f_mul(offset, 5.0f);
+        vec3f_add(hitpos, offset);
+
         newcam_pos[0] = hitpos[0];
-        newcam_pos[1] = approach_f32(hitpos[1],newcam_pos[1],25,-25);
+        newcam_pos[1] = hitpos[1];
         newcam_pos[2] = hitpos[2];
         newcam_pan_x = 0;
         newcam_pan_z = 0;
@@ -541,8 +593,10 @@ static void newcam_position_cam(void) {
     if (newcam_modeflags & NC_FLAG_FOCUSZ)
         newcam_lookat[2] = newcam_pos_target[2]-newcam_pan_z;
 
-    if (newcam_modeflags & NC_FLAG_COLLISION)
-    newcam_collision();
+    if (newcam_modeflags & NC_FLAG_COLLISION) {
+        newcam_collision();
+        newcam_bounding_box();
+    }
 
 }
 

--- a/src/game/bettercamera.inc.h
+++ b/src/game/bettercamera.inc.h
@@ -269,18 +269,18 @@ static void newcam_rotate_button(void) {
             play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gDefaultSoundArgs);
             #endif
             if (newcam_modeflags & NC_FLAG_8D)
-                newcam_yaw_target = newcam_yaw_target+(ivrt(newcam_invertX)*0x2000);
+                newcam_yaw_target = newcam_yaw_target+(ivrt(0)*0x2000);
             else
-                newcam_yaw_target = newcam_yaw_target+(ivrt(newcam_invertX)*0x4000);
+                newcam_yaw_target = newcam_yaw_target+(ivrt(0)*0x4000);
             newcam_centering = 1;
         } else if ((gPlayer1Controller->buttonPressed & R_CBUTTONS) && newcam_analogue == 0) {
             #ifndef nosound
             play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gDefaultSoundArgs);
             #endif
             if (newcam_modeflags & NC_FLAG_8D)
-                newcam_yaw_target = newcam_yaw_target-(ivrt(newcam_invertX)*0x2000);
+                newcam_yaw_target = newcam_yaw_target-(ivrt(0)*0x2000);
             else
-                newcam_yaw_target = newcam_yaw_target-(ivrt(newcam_invertX)*0x4000);
+                newcam_yaw_target = newcam_yaw_target-(ivrt(0)*0x4000);
             newcam_centering = 1;
         }
     } else  if (newcam_modeflags & NC_FLAG_XTURN) {
@@ -314,7 +314,7 @@ static void newcam_rotate_button(void) {
     newcam_framessincec[1] ++;
     if ((gPlayer1Controller->buttonPressed & L_CBUTTONS) && newcam_modeflags & NC_FLAG_XTURN && !(newcam_modeflags & NC_FLAG_8D) && newcam_analogue == 0) {
         if (newcam_framessincec[0] < 6) {
-            newcam_yaw_target = newcam_yaw+(ivrt(newcam_invertX)*0x3000);
+            newcam_yaw_target = newcam_yaw+(ivrt(0)*0x3000);
             newcam_centering = 1;
             #ifndef nosound
             play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gDefaultSoundArgs);
@@ -324,7 +324,7 @@ static void newcam_rotate_button(void) {
     }
     if ((gPlayer1Controller->buttonPressed & R_CBUTTONS) && newcam_modeflags & NC_FLAG_XTURN && !(newcam_modeflags & NC_FLAG_8D) && newcam_analogue == 0) {
         if (newcam_framessincec[1] < 6) {
-            newcam_yaw_target = newcam_yaw-(ivrt(newcam_invertX)*0x3000);
+            newcam_yaw_target = newcam_yaw-(ivrt(0)*0x3000);
             newcam_centering = 1;
             #ifndef nosound
             play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gDefaultSoundArgs);
@@ -350,14 +350,14 @@ static void newcam_rotate_button(void) {
                     #endif
                     if (newcam_stick2[0] > 20) {
                         if (newcam_modeflags & NC_FLAG_8D)
-                            newcam_yaw_target = newcam_yaw_target+(ivrt(newcam_invertX)*0x2000);
+                            newcam_yaw_target = newcam_yaw_target+(ivrt(0)*0x2000);
                         else
-                            newcam_yaw_target = newcam_yaw_target+(ivrt(newcam_invertX)*0x4000);
+                            newcam_yaw_target = newcam_yaw_target+(ivrt(0)*0x4000);
                     } else {
                         if (newcam_modeflags & NC_FLAG_8D)
-                            newcam_yaw_target = newcam_yaw_target-(ivrt(newcam_invertX)*0x2000);
+                            newcam_yaw_target = newcam_yaw_target-(ivrt(0)*0x2000);
                         else
-                            newcam_yaw_target = newcam_yaw_target-(ivrt(newcam_invertX)*0x4000);
+                            newcam_yaw_target = newcam_yaw_target-(ivrt(0)*0x4000);
                     }
                 }
             } else {
@@ -425,9 +425,9 @@ static void newcam_update_values(void) {
     u8 waterflag = 0;
 
     if (newcam_modeflags & NC_FLAG_XTURN)
-        newcam_yaw -= ((newcam_yaw_acc*(newcam_sensitivityX/10))*ivrt(newcam_invertX));
+        newcam_yaw -= ((newcam_yaw_acc*(newcam_sensitivityX/10))*ivrt(0));
     if (((newcam_tilt <= 12000) && (newcam_tilt >= -12000)) && newcam_modeflags & NC_FLAG_YTURN)
-        newcam_tilt += ((newcam_tilt_acc*ivrt(newcam_invertY))*(newcam_sensitivityY/10));
+        newcam_tilt += ((newcam_tilt_acc*ivrt(1))*(newcam_sensitivityY/10));
 
     if (newcam_tilt > 12000)
         newcam_tilt = 12000;

--- a/src/game/bettercamera.inc.h
+++ b/src/game/bettercamera.inc.h
@@ -10,6 +10,7 @@
 #include "engine/surface_collision.h"
 #include "pc/configfile.h"
 #include "pc/controller/controller_mouse.h"
+
 #if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) 
 //quick and dirty fix for some older MinGW.org mingwrt
 #else
@@ -18,7 +19,7 @@
 
 #define NEW_CAM_BOUNDING_BOX_RAYS 4
 #define NEW_CAM_BOUNDING_BOX_HRADIUS 250
-#define NEW_CAM_BOUNDING_BOX_VRADIUS 50
+#define NEW_CAM_BOUNDING_BOX_VRADIUS 100
 
 /**
 Quick explanation of the camera modes
@@ -527,6 +528,7 @@ static void newcam_collision(void) {
     camdir[2] = newcam_pos[2]-newcam_lookat[2];
 
     find_surface_on_ray(newcam_pos_target, camdir, &surf, hitpos);
+
     newcam_coldist = sqrtf((newcam_pos_target[0] - hitpos[0]) * (newcam_pos_target[0] - hitpos[0]) + (newcam_pos_target[1] - hitpos[1]) * (newcam_pos_target[1] - hitpos[1]) + (newcam_pos_target[2] - hitpos[2]) * (newcam_pos_target[2] - hitpos[2]));
 
     if (surf) {

--- a/src/game/mario_actions_airborne.c
+++ b/src/game/mario_actions_airborne.c
@@ -1754,7 +1754,7 @@ s32 act_flying(struct MarioState *m) {
         set_camera_mode(m->area->camera, CAMERA_MODE_BEHIND_MARIO, 1);
 #else
         if (newcam_active == 0)
-            set_camera_mode(m->area->camera, m->area->camera->defMode, 1);
+           set_camera_mode(m->area->camera, CAMERA_MODE_BEHIND_MARIO, 1);
         else
         {
             m->area->camera->mode = CAMERA_MODE_NEWCAM;

--- a/src/game/memory.h
+++ b/src/game/memory.h
@@ -9,6 +9,7 @@
 #define MEMORY_POOL_RIGHT 1
 
 #define GFX_POOL_SIZE (512 * 1024)
+#define DEFAULT_POOL_SIZE (0x165000 * 8)
 
 struct AllocOnlyPool
 {

--- a/src/game/obj_behaviors.c
+++ b/src/game/obj_behaviors.c
@@ -27,7 +27,9 @@
 #include "obj_behaviors.h"
 #include "object_helpers.h"
 #include "object_list_processor.h"
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 #include "rendering_graph_node.h"
 #include "save_file.h"
 #include "spawn_object.h"

--- a/src/game/obj_behaviors.c
+++ b/src/game/obj_behaviors.c
@@ -27,6 +27,7 @@
 #include "obj_behaviors.h"
 #include "object_helpers.h"
 #include "object_list_processor.h"
+#include "pc/configfile.h"
 #include "rendering_graph_node.h"
 #include "save_file.h"
 #include "spawn_object.h"
@@ -531,7 +532,7 @@ void set_object_visibility(struct Object *obj, s32 dist) {
     f32 objZ = obj->oPosZ;
 
 #ifndef NODRAWINGDISTANCE
-    if (is_point_within_radius_of_mario(objX, objY, objZ, dist) == TRUE) {
+    if (is_point_within_radius_of_mario(objX, objY, objZ, dist * configDrawDistance / 100) == TRUE) {
 #endif
         obj->header.gfx.node.flags &= ~GRAPH_RENDER_INVISIBLE;
 #ifndef NODRAWINGDISTANCE

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -35,7 +35,7 @@ static s32 l_counter = 0;
 
 // How to add stuff:
 // strings: add them to include/text_strings.h.in
-//          and to optMainStr[] / opts*Str[]
+//          and to menuStr[] / opts*Str[]
 // options: add them to the relevant options list
 // menus:   add a new submenu definition and a new
 //          option to the optsMain list
@@ -52,7 +52,7 @@ static const u8 optSmallStr[][32] = {
     { TEXT_OPT_R_HIGHLIGHT },
 };
 
-static const u8 optMainStr[][32] = {
+static const u8 menuStr[][32] = {
     { TEXT_OPT_OPTIONS },
     { TEXT_OPT_CAMERA },
     { TEXT_OPT_CONTROLS },
@@ -107,7 +107,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT9 },
 };
 
-static const u8 optBindStr[][32] = {
+static const u8 bindStr[][32] = {
     { TEXT_OPT_UNBOUND },
     { TEXT_OPT_PRESSKEY },
     { TEXT_BIND_A },
@@ -236,24 +236,24 @@ static struct Option optsCamera[] = {
 #endif
 
 static struct Option optsControls[] = {
-    DEF_OPT_BIND( optBindStr[ 2], configKeyA ),
-    DEF_OPT_BIND( optBindStr[ 3], configKeyB ),
-    DEF_OPT_BIND( optBindStr[ 4], configKeyStart ),
-    DEF_OPT_BIND( optBindStr[ 5], configKeyL ),
-    DEF_OPT_BIND( optBindStr[ 6], configKeyR ),
-    DEF_OPT_BIND( optBindStr[ 7], configKeyZ ),
-    DEF_OPT_BIND( optBindStr[ 8], configKeyCUp ),
-    DEF_OPT_BIND( optBindStr[ 9], configKeyCDown ),
-    DEF_OPT_BIND( optBindStr[10], configKeyCLeft ),
-    DEF_OPT_BIND( optBindStr[11], configKeyCRight ),
-    DEF_OPT_BIND( optBindStr[12], configKeyStickUp ),
-    DEF_OPT_BIND( optBindStr[13], configKeyStickDown ),
-    DEF_OPT_BIND( optBindStr[14], configKeyStickLeft ),
-    DEF_OPT_BIND( optBindStr[15], configKeyStickRight ),
+    DEF_OPT_BIND( bindStr[ 2], configKeyA ),
+    DEF_OPT_BIND( bindStr[ 3], configKeyB ),
+    DEF_OPT_BIND( bindStr[ 4], configKeyStart ),
+    DEF_OPT_BIND( bindStr[ 5], configKeyL ),
+    DEF_OPT_BIND( bindStr[ 6], configKeyR ),
+    DEF_OPT_BIND( bindStr[ 7], configKeyZ ),
+    DEF_OPT_BIND( bindStr[ 8], configKeyCUp ),
+    DEF_OPT_BIND( bindStr[ 9], configKeyCDown ),
+    DEF_OPT_BIND( bindStr[10], configKeyCLeft ),
+    DEF_OPT_BIND( bindStr[11], configKeyCRight ),
+    DEF_OPT_BIND( bindStr[12], configKeyStickUp ),
+    DEF_OPT_BIND( bindStr[13], configKeyStickDown ),
+    DEF_OPT_BIND( bindStr[14], configKeyStickLeft ),
+    DEF_OPT_BIND( bindStr[15], configKeyStickRight ),
     // max deadzone is 31000; this is less than the max range of ~32768, but this
     // way, the player can't accidentally lock themselves out of using the stick
-    DEF_OPT_SCROLL( optBindStr[16], &configStickDeadzone, 0, 100, 1 ),
-    DEF_OPT_SCROLL( optBindStr[17], &configRumbleStrength, 0, 100, 1)
+    DEF_OPT_SCROLL( bindStr[16], &configStickDeadzone, 0, 100, 1 ),
+    DEF_OPT_SCROLL( bindStr[17], &configRumbleStrength, 0, 100, 1)
 };
 
 static struct Option optsVideo[] = {
@@ -288,28 +288,28 @@ static struct Option optsCheats[] = {
 /* submenu definitions */
 
 #ifdef BETTERCAMERA
-static struct SubMenu menuCamera   = DEF_SUBMENU( optMainStr[1], optsCamera );
+static struct SubMenu menuCamera   = DEF_SUBMENU( menuStr[1], optsCamera );
 #endif
-static struct SubMenu menuControls = DEF_SUBMENU( optMainStr[2], optsControls );
-static struct SubMenu menuVideo    = DEF_SUBMENU( optMainStr[3], optsVideo );
-static struct SubMenu menuAudio    = DEF_SUBMENU( optMainStr[4], optsAudio );
-static struct SubMenu menuCheats   = DEF_SUBMENU( optMainStr[6], optsCheats );
+static struct SubMenu menuControls = DEF_SUBMENU( menuStr[2], optsControls );
+static struct SubMenu menuVideo    = DEF_SUBMENU( menuStr[3], optsVideo );
+static struct SubMenu menuAudio    = DEF_SUBMENU( menuStr[4], optsAudio );
+static struct SubMenu menuCheats   = DEF_SUBMENU( menuStr[6], optsCheats );
 
 /* main options menu definition */
 
 static struct Option optsMain[] = {
 #ifdef BETTERCAMERA
-    DEF_OPT_SUBMENU( optMainStr[1], &menuCamera ),
+    DEF_OPT_SUBMENU( menuStr[1], &menuCamera ),
 #endif
-    DEF_OPT_SUBMENU( optMainStr[2], &menuControls ),
-    DEF_OPT_SUBMENU( optMainStr[3], &menuVideo ),
-    DEF_OPT_SUBMENU( optMainStr[4], &menuAudio ),
-    DEF_OPT_BUTTON ( optMainStr[5], optmenu_act_exit ),
+    DEF_OPT_SUBMENU( menuStr[2], &menuControls ),
+    DEF_OPT_SUBMENU( menuStr[3], &menuVideo ),
+    DEF_OPT_SUBMENU( menuStr[4], &menuAudio ),
+    DEF_OPT_BUTTON ( menuStr[5], optmenu_act_exit ),
     // NOTE: always keep cheats the last option here because of the half-assed way I toggle them
-    DEF_OPT_SUBMENU( optMainStr[6], &menuCheats )
+    DEF_OPT_SUBMENU( menuStr[6], &menuCheats )
 };
 
-static struct SubMenu menuMain = DEF_SUBMENU( optMainStr[0], optsMain );
+static struct SubMenu menuMain = DEF_SUBMENU( menuStr[0], optsMain );
 
 /* implementation */
 
@@ -388,9 +388,9 @@ static void optmenu_draw_opt(const struct Option *opt, s16 x, s16 y, u8 sel) {
                 // TODO: button names
                 if (opt->uval[i] == VK_INVALID) {
                     if (optmenu_binding && white)
-                        optmenu_draw_text(x, y-13, optBindStr[1], 1);
+                        optmenu_draw_text(x, y-13, bindStr[1], 1);
                     else
-                        optmenu_draw_text(x, y-13, optBindStr[0], white);
+                        optmenu_draw_text(x, y-13, bindStr[0], white);
                 } else {
                     uint_to_hex(opt->uval[i], buf);
                     optmenu_draw_text(x, y-13, buf, white);

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -315,7 +315,6 @@ static struct SubMenu menuMain = DEF_SUBMENU( menuStr[0], optsMain );
 
 static s32 optmenu_option_timer = 0;
 static u8 optmenu_hold_count = 0;
-static s32 optmenu_sin_timer = 0;
 
 static struct SubMenu *currentMenu = &menuMain;
 
@@ -454,7 +453,6 @@ static inline s16 get_hudstr_centered_x(const s16 sx, const u8 *str) {
 void optmenu_draw(void) {
     s16 scroll;
     s16 scrollpos;
-    f32 sinpos;
 
     const s16 labelX = get_hudstr_centered_x(160, currentMenu->label);
     gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
@@ -478,11 +476,10 @@ void optmenu_draw(void) {
             optmenu_draw_opt(&currentMenu->opts[i], 160, scroll, (currentMenu->select == i));
     }
 
-    sinpos = sins(optmenu_sin_timer*5000)*4;
     gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, 255);
-    print_generic_string(80 - sinpos, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[2]);
-    print_generic_string(224 + sinpos, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[3]);
+    print_generic_string(72, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[2]);
+    print_generic_string(232, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[3]);
     gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
 }
 
@@ -542,8 +539,6 @@ void optmenu_check_buttons(void) {
 
     if (gPlayer1Controller->buttonPressed & R_TRIG)
         optmenu_toggle();
-    
-    optmenu_sin_timer++;
 
     /* Enables cheats if the user press the L trigger 3 times while in the options menu. Also plays a sound. */
     

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -1,7 +1,7 @@
 #ifdef EXT_OPTIONS_MENU
 
 #include "sm64.h"
-#include "include/text_strings.h"
+#include "text_strings.h"
 #include "engine/math_util.h"
 #include "audio/external.h"
 #include "game/camera.h"
@@ -35,7 +35,7 @@ static s32 l_counter = 0;
 
 // How to add stuff:
 // strings: add them to include/text_strings.h.in
-//          and to menuStr[] / opts*Str[]
+//          and to optMainStr[] / opts*Str[]
 // options: add them to the relevant options list
 // menus:   add a new submenu definition and a new
 //          option to the optsMain list
@@ -45,10 +45,14 @@ static const u8 toggleStr[][16] = {
     { TEXT_OPT_ENABLED },
 };
 
-static const u8 menuStr[][32] = {
-    { TEXT_OPT_HIGHLIGHT },
+static const u8 optSmallStr[][32] = {
     { TEXT_OPT_BUTTON1 },
     { TEXT_OPT_BUTTON2 },
+    { TEXT_OPT_L_HIGHLIGHT },
+    { TEXT_OPT_R_HIGHLIGHT },
+};
+
+static const u8 optMainStr[][32] = {
     { TEXT_OPT_OPTIONS },
     { TEXT_OPT_CAMERA },
     { TEXT_OPT_CONTROLS },
@@ -56,7 +60,6 @@ static const u8 menuStr[][32] = {
     { TEXT_OPT_AUDIO },
     { TEXT_EXIT_GAME },
     { TEXT_OPT_CHEATS },
-
 };
 
 static const u8 optsCameraStr[][32] = {
@@ -104,7 +107,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT9 },
 };
 
-static const u8 bindStr[][32] = {
+static const u8 optBindStr[][32] = {
     { TEXT_OPT_UNBOUND },
     { TEXT_OPT_PRESSKEY },
     { TEXT_BIND_A },
@@ -122,7 +125,7 @@ static const u8 bindStr[][32] = {
     { TEXT_BIND_LEFT },
     { TEXT_BIND_RIGHT },
     { TEXT_OPT_DEADZONE },
-    { TEXT_OPT_RUMBLE }
+    { TEXT_OPT_RUMBLE },
 };
 
 static const u8 *filterChoices[] = {
@@ -233,24 +236,24 @@ static struct Option optsCamera[] = {
 #endif
 
 static struct Option optsControls[] = {
-    DEF_OPT_BIND( bindStr[ 2], configKeyA ),
-    DEF_OPT_BIND( bindStr[ 3], configKeyB ),
-    DEF_OPT_BIND( bindStr[ 4], configKeyStart ),
-    DEF_OPT_BIND( bindStr[ 5], configKeyL ),
-    DEF_OPT_BIND( bindStr[ 6], configKeyR ),
-    DEF_OPT_BIND( bindStr[ 7], configKeyZ ),
-    DEF_OPT_BIND( bindStr[ 8], configKeyCUp ),
-    DEF_OPT_BIND( bindStr[ 9], configKeyCDown ),
-    DEF_OPT_BIND( bindStr[10], configKeyCLeft ),
-    DEF_OPT_BIND( bindStr[11], configKeyCRight ),
-    DEF_OPT_BIND( bindStr[12], configKeyStickUp ),
-    DEF_OPT_BIND( bindStr[13], configKeyStickDown ),
-    DEF_OPT_BIND( bindStr[14], configKeyStickLeft ),
-    DEF_OPT_BIND( bindStr[15], configKeyStickRight ),
+    DEF_OPT_BIND( optBindStr[ 2], configKeyA ),
+    DEF_OPT_BIND( optBindStr[ 3], configKeyB ),
+    DEF_OPT_BIND( optBindStr[ 4], configKeyStart ),
+    DEF_OPT_BIND( optBindStr[ 5], configKeyL ),
+    DEF_OPT_BIND( optBindStr[ 6], configKeyR ),
+    DEF_OPT_BIND( optBindStr[ 7], configKeyZ ),
+    DEF_OPT_BIND( optBindStr[ 8], configKeyCUp ),
+    DEF_OPT_BIND( optBindStr[ 9], configKeyCDown ),
+    DEF_OPT_BIND( optBindStr[10], configKeyCLeft ),
+    DEF_OPT_BIND( optBindStr[11], configKeyCRight ),
+    DEF_OPT_BIND( optBindStr[12], configKeyStickUp ),
+    DEF_OPT_BIND( optBindStr[13], configKeyStickDown ),
+    DEF_OPT_BIND( optBindStr[14], configKeyStickLeft ),
+    DEF_OPT_BIND( optBindStr[15], configKeyStickRight ),
     // max deadzone is 31000; this is less than the max range of ~32768, but this
     // way, the player can't accidentally lock themselves out of using the stick
-    DEF_OPT_SCROLL( bindStr[16], &configStickDeadzone, 0, 100, 1 ),
-    DEF_OPT_SCROLL( bindStr[17], &configRumbleStrength, 0, 100, 1)
+    DEF_OPT_SCROLL( optBindStr[16], &configStickDeadzone, 0, 100, 1 ),
+    DEF_OPT_SCROLL( optBindStr[17], &configRumbleStrength, 0, 100, 1)
 };
 
 static struct Option optsVideo[] = {
@@ -285,33 +288,34 @@ static struct Option optsCheats[] = {
 /* submenu definitions */
 
 #ifdef BETTERCAMERA
-static struct SubMenu menuCamera   = DEF_SUBMENU( menuStr[4], optsCamera );
+static struct SubMenu menuCamera   = DEF_SUBMENU( optMainStr[1], optsCamera );
 #endif
-static struct SubMenu menuControls = DEF_SUBMENU( menuStr[5], optsControls );
-static struct SubMenu menuVideo    = DEF_SUBMENU( menuStr[6], optsVideo );
-static struct SubMenu menuAudio    = DEF_SUBMENU( menuStr[7], optsAudio );
-static struct SubMenu menuCheats   = DEF_SUBMENU( menuStr[9], optsCheats );
+static struct SubMenu menuControls = DEF_SUBMENU( optMainStr[2], optsControls );
+static struct SubMenu menuVideo    = DEF_SUBMENU( optMainStr[3], optsVideo );
+static struct SubMenu menuAudio    = DEF_SUBMENU( optMainStr[4], optsAudio );
+static struct SubMenu menuCheats   = DEF_SUBMENU( optMainStr[6], optsCheats );
 
 /* main options menu definition */
 
 static struct Option optsMain[] = {
 #ifdef BETTERCAMERA
-    DEF_OPT_SUBMENU( menuStr[4], &menuCamera ),
+    DEF_OPT_SUBMENU( optMainStr[1], &menuCamera ),
 #endif
-    DEF_OPT_SUBMENU( menuStr[5], &menuControls ),
-    DEF_OPT_SUBMENU( menuStr[6], &menuVideo ),
-    DEF_OPT_SUBMENU( menuStr[7], &menuAudio ),
-    DEF_OPT_BUTTON ( menuStr[8], optmenu_act_exit ),
+    DEF_OPT_SUBMENU( optMainStr[2], &menuControls ),
+    DEF_OPT_SUBMENU( optMainStr[3], &menuVideo ),
+    DEF_OPT_SUBMENU( optMainStr[4], &menuAudio ),
+    DEF_OPT_BUTTON ( optMainStr[5], optmenu_act_exit ),
     // NOTE: always keep cheats the last option here because of the half-assed way I toggle them
-    DEF_OPT_SUBMENU( menuStr[9], &menuCheats )
+    DEF_OPT_SUBMENU( optMainStr[6], &menuCheats )
 };
 
-static struct SubMenu menuMain = DEF_SUBMENU( menuStr[3], optsMain );
+static struct SubMenu menuMain = DEF_SUBMENU( optMainStr[0], optsMain );
 
 /* implementation */
 
 static s32 optmenu_option_timer = 0;
 static u8 optmenu_hold_count = 0;
+static s32 optmenu_sin_timer = 0;
 
 static struct SubMenu *currentMenu = &menuMain;
 
@@ -384,9 +388,9 @@ static void optmenu_draw_opt(const struct Option *opt, s16 x, s16 y, u8 sel) {
                 // TODO: button names
                 if (opt->uval[i] == VK_INVALID) {
                     if (optmenu_binding && white)
-                        optmenu_draw_text(x, y-13, bindStr[1], 1);
+                        optmenu_draw_text(x, y-13, optBindStr[1], 1);
                     else
-                        optmenu_draw_text(x, y-13, bindStr[0], white);
+                        optmenu_draw_text(x, y-13, optBindStr[0], white);
                 } else {
                     uint_to_hex(opt->uval[i], buf);
                     optmenu_draw_text(x, y-13, buf, white);
@@ -450,6 +454,7 @@ static inline s16 get_hudstr_centered_x(const s16 sx, const u8 *str) {
 void optmenu_draw(void) {
     s16 scroll;
     s16 scrollpos;
+    f32 sinpos;
 
     const s16 labelX = get_hudstr_centered_x(160, currentMenu->label);
     gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
@@ -465,6 +470,7 @@ void optmenu_draw(void) {
 
     gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
     gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, 80, SCREEN_WIDTH, SCREEN_HEIGHT);
+    
     for (u8 i = 0; i < currentMenu->numOpts; i++) {
         scroll = 140 - 32 * i + currentMenu->scroll * 32;
         // FIXME: just start from the first visible option bruh
@@ -472,19 +478,18 @@ void optmenu_draw(void) {
             optmenu_draw_opt(&currentMenu->opts[i], 160, scroll, (currentMenu->select == i));
     }
 
+    sinpos = sins(optmenu_sin_timer*5000)*4;
     gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-    gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, 255);
-    gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
-    print_hud_lut_string(HUD_LUT_GLOBAL, 80, 90 + (32 * (currentMenu->select - currentMenu->scroll)), menuStr[0]);
-    print_hud_lut_string(HUD_LUT_GLOBAL, 224, 90 + (32 * (currentMenu->select - currentMenu->scroll)), menuStr[0]);
-    gSPDisplayList(gDisplayListHead++, dl_rgba16_text_end);
+    print_generic_string(80 - sinpos, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[2]);
+    print_generic_string(224 + sinpos, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[3]);
+    gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
 }
 
 //This has been separated for interesting reasons. Don't question it.
 void optmenu_draw_prompt(void) {
     gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
-    optmenu_draw_text(264, 212, menuStr[1 + optmenu_open], 0);
+    optmenu_draw_text(264, 212, optSmallStr[optmenu_open], 0);
     gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
 }
 
@@ -506,7 +511,6 @@ void optmenu_toggle(void) {
 
         currentMenu = &menuMain;
         optmenu_open = 1;
-        
         /* Resets l_counter to 0 every time the options menu is open */
         l_counter = 0;
     } else {
@@ -539,6 +543,8 @@ void optmenu_check_buttons(void) {
     if (gPlayer1Controller->buttonPressed & R_TRIG)
         optmenu_toggle();
     
+    optmenu_sin_timer++;
+
     /* Enables cheats if the user press the L trigger 3 times while in the options menu. Also plays a sound. */
     
     if ((gPlayer1Controller->buttonPressed & L_TRIG) && !Cheats.EnableCheats) {

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -85,6 +85,7 @@ static const u8 optsVideoStr[][32] = {
     { TEXT_OPT_AUTO },
     { TEXT_OPT_HUD },
     { TEXT_OPT_THREEPT },
+    { TEXT_OPT_DRAWDIST },
     { TEXT_OPT_APPLY },
 };
 
@@ -261,8 +262,11 @@ static struct Option optsVideo[] = {
     DEF_OPT_TOGGLE( optsVideoStr[5], &configWindow.vsync ),
     DEF_OPT_CHOICE( optsVideoStr[1], &configFiltering, filterChoices ),
     DEF_OPT_TOGGLE( optsVideoStr[7], &configHUD ),
+#ifndef NODRAWINGDISTANCE
+    DEF_OPT_SCROLL( optsVideoStr[9], &configDrawDistance, 50, 509, 10 ),
+#endif
     DEF_OPT_BUTTON( optsVideoStr[4], optvideo_reset_window ),
-    DEF_OPT_BUTTON( optsVideoStr[9], optvideo_apply ),
+    DEF_OPT_BUTTON( optsVideoStr[10], optvideo_apply ),
 };
 
 static struct Option optsAudio[] = {

--- a/src/game/save_file.c
+++ b/src/game/save_file.c
@@ -615,6 +615,12 @@ u32 save_file_get_star_flags(s32 fileIndex, s32 courseIndex) {
 
     return starFlags;
 }
+u32 save_file_get_cannon_flags(s32 fileIndex, s32 courseIndex) {
+    
+    if (gSaveBuffer.files[fileIndex][0].courseStars[courseIndex+1] & 0x80){return 1;}
+
+    return 0;
+}
 
 /**
  * Add to the bitset of obtained stars in the specified course.

--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -135,6 +135,7 @@ void save_file_set_flags(u32 flags);
 void save_file_clear_flags(u32 flags);
 u32 save_file_get_flags(void);
 u32 save_file_get_star_flags(s32 fileIndex, s32 courseIndex);
+u32 save_file_get_cannon_flags(s32 fileIndex, s32 courseIndex);
 void save_file_set_star_flags(s32 fileIndex, s32 courseIndex, u32 starFlags);
 s32 save_file_get_course_coin_score(s32 fileIndex, s32 courseIndex);
 s32 save_file_is_cannon_unlocked(void);

--- a/src/game/text_save.inc.h
+++ b/src/game/text_save.inc.h
@@ -81,7 +81,7 @@ static s32 write_text_save(s32 fileIndex) {
     struct MainMenuSaveData *menudata;
     char filename[SYS_MAX_PATH] = { 0 };
     char value[64];
-    u32 i, bit, flags, coins, stars, starFlags;
+    u32 i, bit, flags, coins, stars, starFlags, cannonFlag;
 
     if (snprintf(filename, sizeof(filename), FILENAME_FORMAT, fs_writepath, fileIndex) < 0)
         return -1;
@@ -133,9 +133,10 @@ static s32 write_text_save(s32 fileIndex) {
     for (i = 0; i < NUM_COURSES; i++) {
         stars = save_file_get_star_flags(fileIndex, i);
         coins = save_file_get_course_coin_score(fileIndex, i);
+        cannonFlag = save_file_get_cannon_flags(fileIndex, i);
         starFlags = int_to_bin(stars);      // 63 -> 111111
             
-        fprintf(file, "%s = \"%d, %07d\"\n", sav_courses[i], coins, starFlags);
+        fprintf(file, "%s = \"%d, %07d, %d\"\n", sav_courses[i], coins, starFlags,cannonFlag);
     }
 
     fprintf(file, "\n[bonus]\n");
@@ -208,7 +209,7 @@ static s32 read_text_save(s32 fileIndex) {
     const char *value;
     ini_t *savedata;
     
-    u32 i, flag, coins, stars, starFlags;
+    u32 i, flag, coins, stars, starFlags, cannonFlag;
     u32 capArea;
     
     if (snprintf(filename, sizeof(filename), FILENAME_FORMAT, fs_writepath, fileIndex) < 0)
@@ -255,9 +256,10 @@ static s32 read_text_save(s32 fileIndex) {
     for (i = 0; i < NUM_COURSES; i++) {
         value = ini_get(savedata, "courses", sav_courses[i]);
         if (value) {
-            sscanf(value, "%d, %d", &coins, &stars); 
+            sscanf(value, "%d, %d, %d", &coins, &stars, &cannonFlag); 
             starFlags = bin_to_int(stars);      // 111111 -> 63
-
+            cannonFlag <<= 7; //Shifts the bit to the most significant bit.
+            save_file_set_star_flags(fileIndex, i+1, cannonFlag); //
             save_file_set_star_flags(fileIndex, i, starFlags);
             gSaveBuffer.files[fileIndex][0].courseCoinScores[i] = coins;
         }

--- a/src/pc/audio/audio_sdl1.c
+++ b/src/pc/audio/audio_sdl1.c
@@ -1,0 +1,190 @@
+#ifdef AAPI_SDL1
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <SDL/SDL.h>
+
+#include "audio_api.h"
+
+#define SNDPACKETLEN (8 * 1024)
+
+// this is basically SDL_dataqueue but slightly less generic
+
+typedef struct sndpacket {
+    size_t datalen;         /* bytes currently in use in this packet. */
+    size_t startpos;        /* bytes currently consumed in this packet. */
+    struct sndpacket *next; /* next item in linked list. */
+    Uint8 data[];           /* packet data */
+} sndpacket_t;
+
+static sndpacket_t *qhead;
+static sndpacket_t *qtail;
+static sndpacket_t *qpool;
+static size_t queued;
+
+static SDL_AudioSpec aspec;
+static int was_init = 0;
+
+static void sndqueue_init(const size_t bufsize) {
+    const size_t wantpackets = (bufsize + (SNDPACKETLEN - 1)) / SNDPACKETLEN;
+    for (size_t i = 0; i < wantpackets; ++i) {
+        sndpacket_t *packet = malloc(sizeof(sndpacket_t) + SNDPACKETLEN);
+        if (packet) {
+            packet->datalen = 0;
+            packet->startpos = 0;
+            packet->next = qpool;
+            qpool = packet;
+        }
+    }
+}
+
+static size_t sndqueue_read(void *buf, size_t len) {
+    sndpacket_t *packet;
+    Uint8 *ptr = buf;
+
+    while ((len > 0) && ((packet = qhead) != NULL)) {
+        const size_t avail = packet->datalen - packet->startpos;
+        const size_t tx = (len < avail) ? len : avail;
+
+        memcpy(ptr, packet->data + packet->startpos, tx);
+        packet->startpos += tx;
+        ptr += tx;
+        queued -= tx;
+        len -= tx;
+
+        if (packet->startpos == packet->datalen) {
+            qhead = packet->next;
+            packet->next = qpool;
+            qpool = packet;
+        }
+    }
+
+    if (qhead == NULL)
+        qtail = NULL;
+
+    return (size_t)(ptr - (Uint8*)buf);
+}
+
+static inline sndpacket_t *alloc_sndpacket(void) {
+    sndpacket_t *packet = qpool;
+
+    if (packet) {
+        qpool = packet->next;
+    } else {
+        packet = malloc(sizeof(sndpacket_t) + SNDPACKETLEN);
+        if (!packet) return NULL;
+    }
+
+    packet->datalen = 0;
+    packet->startpos = 0;
+    packet->next = NULL;
+
+    if (qtail == NULL)
+        qhead = packet;
+    else
+        qtail->next = packet;
+    qtail = packet;
+
+    return packet;
+}
+
+static int sndqueue_push(const void *data, size_t len) {
+    sndpacket_t *orighead = qhead;
+    sndpacket_t *origtail = qtail;
+    size_t origlen = origtail ? origtail->datalen : 0;
+    Uint8 *ptr = data;
+
+    while (len > 0) {
+        sndpacket_t *packet = qtail;
+        if (!packet || (packet->datalen >= SNDPACKETLEN)) {
+            packet = alloc_sndpacket();
+            if (!packet) {
+                // out of memory, fuck everything
+                return -1;
+            }
+        }
+
+        const size_t room = SNDPACKETLEN - packet->datalen;
+        const size_t datalen = (len < room) ? len : room;
+        memcpy(packet->data + packet->datalen, ptr, datalen);
+        ptr += datalen;
+        len -= datalen;
+        packet->datalen += datalen;
+        queued += datalen;
+    }
+
+    return 0;
+}
+
+static void audio_drain(void *user, Uint8 *buf, int len) {
+    const size_t tx = sndqueue_read(buf, len);
+    buf += tx;
+    len -= (int)tx;
+    if (len > 0) memset(buf, aspec.silence, len);
+}
+
+static bool audio_sdl_init(void) {
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
+        fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
+        return false;
+    }
+
+    SDL_AudioSpec want, have;
+    memset(&want, 0, sizeof(want));
+    want.freq = 32000;
+    want.format = AUDIO_S16SYS;
+    want.channels = 2;
+    want.samples = 512;
+    want.callback = audio_drain;
+    if (SDL_OpenAudio(&want, &have) == -1) {
+        fprintf(stderr, "SDL_OpenAudio error: %s\n", SDL_GetError());
+        return false;
+    }
+
+    aspec = have;
+
+    was_init = 1;
+    SDL_PauseAudio(0);
+
+    return true;
+}
+
+static int audio_sdl_buffered(void) {
+    SDL_LockAudio();
+    int len = queued / 4;
+    SDL_UnlockAudio();
+    return len;
+}
+
+static int audio_sdl_get_desired_buffered(void) {
+    return 1100;
+}
+
+static void audio_sdl_play(const uint8_t *buf, size_t len) {
+    SDL_LockAudio();
+    // Don't fill the audio buffer too much in case this happens
+    if (queued / 4 < 6000)
+        sndqueue_push(buf, len);
+    SDL_UnlockAudio();
+}
+
+static void audio_sdl_shutdown(void)  {
+    if (SDL_WasInit(SDL_INIT_AUDIO)) {
+        if (was_init) {
+            SDL_CloseAudio();
+            was_init = 0;
+        }
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    }
+}
+
+struct AudioAPI audio_sdl = {
+    audio_sdl_init,
+    audio_sdl_buffered,
+    audio_sdl_get_desired_buffered,
+    audio_sdl_play,
+    audio_sdl_shutdown
+};
+
+#endif

--- a/src/pc/audio/audio_sdl2.c
+++ b/src/pc/audio/audio_sdl2.c
@@ -11,10 +11,11 @@ static bool audio_sdl_init(void) {
         fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
         return false;
     }
+
     SDL_AudioSpec want, have;
     SDL_zero(want);
     want.freq = 32000;
-    want.format = AUDIO_S16;
+    want.format = AUDIO_S16SYS;
     want.channels = 2;
     want.samples = 512;
     want.callback = NULL;

--- a/src/pc/cliopts.c
+++ b/src/pc/cliopts.c
@@ -34,6 +34,12 @@ static inline int arg_string(const char *name, const char *value, char *target) 
     return 1;
 }
 
+static inline int arg_uint(const char *name, const char *value, unsigned int *target) {
+    const unsigned long int v = strtoul(value, NULL, 0);
+    *target = v;
+    return 1;
+}
+
 void parse_cli_opts(int argc, char* argv[]) {
     // Initialize options with false values.
     memset(&gCLIOpts, 0, sizeof(gCLIOpts));
@@ -50,6 +56,9 @@ void parse_cli_opts(int argc, char* argv[]) {
 
         else if (strcmp(argv[i], "--cheats") == 0) // Enable cheats menu
             Cheats.EnableCheats = true;
+
+        else if (strcmp(argv[i], "--poolsize") == 0) // Main pool size
+            arg_uint("--poolsize", argv[++i], &gCLIOpts.PoolSize);
 
         else if (strcmp(argv[i], "--configfile") == 0 && (i + 1) < argc)
             arg_string("--configfile", argv[++i], gCLIOpts.ConfigFile);

--- a/src/pc/cliopts.c
+++ b/src/pc/cliopts.c
@@ -3,6 +3,7 @@
 #include "cheats.h"
 #include "pc_main.h"
 #include "platform.h"
+#include "macros.h"
 
 #include <strings.h>
 #include <stdlib.h>
@@ -34,7 +35,7 @@ static inline int arg_string(const char *name, const char *value, char *target) 
     return 1;
 }
 
-static inline int arg_uint(const char *name, const char *value, unsigned int *target) {
+static inline int arg_uint(UNUSED const char *name, const char *value, unsigned int *target) {
     const unsigned long int v = strtoul(value, NULL, 0);
     *target = v;
     return 1;
@@ -59,6 +60,9 @@ void parse_cli_opts(int argc, char* argv[]) {
 
         else if (strcmp(argv[i], "--poolsize") == 0) // Main pool size
             arg_uint("--poolsize", argv[++i], &gCLIOpts.PoolSize);
+
+        else if (strcmp(argv[i], "--syncframes") == 0) // VBlanks to wait
+            arg_uint("--syncframes", argv[++i], &gCLIOpts.SyncFrames);
 
         else if (strcmp(argv[i], "--configfile") == 0 && (i + 1) < argc)
             arg_string("--configfile", argv[++i], gCLIOpts.ConfigFile);

--- a/src/pc/cliopts.h
+++ b/src/pc/cliopts.h
@@ -6,6 +6,7 @@
 struct PCCLIOptions  {
     unsigned int SkipIntro;
     unsigned int FullScreen;
+    unsigned int PoolSize;
     char ConfigFile[SYS_MAX_PATH];
     char SavePath[SYS_MAX_PATH];
     char GameDir[SYS_MAX_PATH];

--- a/src/pc/cliopts.h
+++ b/src/pc/cliopts.h
@@ -7,6 +7,7 @@ struct PCCLIOptions  {
     unsigned int SkipIntro;
     unsigned int FullScreen;
     unsigned int PoolSize;
+    unsigned int SyncFrames;
     char ConfigFile[SYS_MAX_PATH];
     char SavePath[SYS_MAX_PATH];
     char GameDir[SYS_MAX_PATH];

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -90,6 +90,9 @@ bool         configCameraMouse   = false;
 #endif
 bool         configSkipIntro     = 0;
 bool         configHUD           = true;
+#ifndef NODRAWINGDISTANCE
+unsigned int configDrawDistance  = 100;
+#endif
 #ifdef DISCORDRPC
 bool         configDiscordRPC    = true;
 #endif
@@ -102,6 +105,9 @@ static const struct ConfigOption options[] = {
     {.name = "window_h",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.h},
     {.name = "vsync",                .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.vsync},
     {.name = "texture_filtering",    .type = CONFIG_TYPE_UINT, .uintValue = &configFiltering},
+    #ifndef NODRAWINGDISTANCE
+    {.name = "drawing_distance",     .type = CONFIG_TYPE_UINT, .uintValue = &configDrawDistance},
+    #endif
     {.name = "master_volume",        .type = CONFIG_TYPE_UINT, .uintValue = &configMasterVolume},
     {.name = "music_volume",         .type = CONFIG_TYPE_UINT, .uintValue = &configMusicVolume},
     {.name = "sfx_volume",           .type = CONFIG_TYPE_UINT, .uintValue = &configSfxVolume},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -55,6 +55,9 @@ extern bool         configCameraMouse;
 extern bool         configCameraAnalog;
 #endif
 extern bool         configHUD;
+#ifndef NODRAWINGDISTANCE
+extern unsigned int configDrawDistance;
+#endif
 extern bool         configSkipIntro;
 #ifdef DISCORDRPC
 extern bool         configDiscordRPC;

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -13,16 +13,15 @@
 
 static struct ControllerAPI *controller_implementations[] = {
     &controller_recorded_tas,
-    #ifdef CAPI_SDL2
+    #if defined(CAPI_SDL2) || defined(CAPI_SDL1)
     &controller_sdl,
     #endif
     &controller_keyboard,
 };
 
 s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *status) {
-    for (size_t i = 0; i < sizeof(controller_implementations) / sizeof(struct ControllerAPI *); i++) {
+    for (size_t i = 0; i < sizeof(controller_implementations) / sizeof(struct ControllerAPI *); i++)
         controller_implementations[i]->init();
-    }
     *controllerBits = 1;
     return 0;
 }

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -33,16 +33,14 @@ s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *
 s32 osMotorStart(UNUSED void *pfs) {
     // Since rumble stops by osMotorStop, its duration is not nessecary.
     // Set it to 5 seconds and hope osMotorStop() is called in time.
-    if (configRumbleStrength>0){
+    if (configRumbleStrength)
         controller_rumble_play(configRumbleStrength / 100.0f, 5.0f);
-    }
     return 0;
 }
 
 s32 osMotorStop(UNUSED void *pfs) {
-    if (configRumbleStrength>0){
+    if (configRumbleStrength)
         controller_rumble_stop();
-    }
     return 0;
 }
 

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -13,7 +13,9 @@
 
 static struct ControllerAPI *controller_implementations[] = {
     &controller_recorded_tas,
+    #ifdef CAPI_SDL2
     &controller_sdl,
+    #endif
     &controller_keyboard,
 };
 

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -33,12 +33,16 @@ s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *
 s32 osMotorStart(UNUSED void *pfs) {
     // Since rumble stops by osMotorStop, its duration is not nessecary.
     // Set it to 5 seconds and hope osMotorStop() is called in time.
-    controller_rumble_play(configRumbleStrength / 100.0f, 5.0f);
+    if (configRumbleStrength>0){
+        controller_rumble_play(configRumbleStrength / 100.0f, 5.0f);
+    }
     return 0;
 }
 
 s32 osMotorStop(UNUSED void *pfs) {
-    controller_rumble_stop();
+    if (configRumbleStrength>0){
+        controller_rumble_stop();
+    }
     return 0;
 }
 

--- a/src/pc/controller/controller_sdl1.c
+++ b/src/pc/controller/controller_sdl1.c
@@ -1,0 +1,285 @@
+#ifdef CAPI_SDL1
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <math.h>
+
+#include <SDL/SDL.h>
+
+// Analog camera movement by Pathétique (github.com/vrmiguel), y0shin and Mors
+// Contribute or communicate bugs at github.com/vrmiguel/sm64-analog-camera
+
+#include <ultra64.h>
+
+#include "controller_api.h"
+#include "controller_sdl.h"
+#include "../configfile.h"
+#include "../platform.h"
+#include "../fs/fs.h"
+
+#include "game/level_update.h"
+
+// mouse buttons are also in the controller namespace (why), just offset 0x100
+#define VK_OFS_SDL_MOUSE 0x0100
+#define VK_BASE_SDL_MOUSE (VK_BASE_SDL_GAMEPAD + VK_OFS_SDL_MOUSE)
+#define MAX_JOYBINDS 32
+#define MAX_MOUSEBUTTONS 8 // arbitrary
+#define MAX_JOYBUTTONS 32  // arbitrary; includes virtual keys for triggers
+#define AXIS_THRESHOLD (30 * 256)
+
+enum {
+    JOY_AXIS_LEFTX,
+    JOY_AXIS_LEFTY,
+    JOY_AXIS_RIGHTX,
+    JOY_AXIS_RIGHTY,
+    JOY_AXIS_LTRIG,
+    JOY_AXIS_RTRIG,
+    MAX_AXES,
+};
+
+int mouse_x;
+int mouse_y;
+
+#ifdef BETTERCAMERA
+extern u8 newcam_mouse;
+#endif
+
+static bool init_ok;
+static SDL_Joystick *sdl_joy;
+
+static u32 num_joy_binds = 0;
+static u32 num_mouse_binds = 0;
+static u32 joy_binds[MAX_JOYBINDS][2];
+static u32 mouse_binds[MAX_JOYBINDS][2];
+static int joy_axis_binds[MAX_AXES] = { 0, 1, 2, 3, 4, 5 };
+
+static bool joy_buttons[MAX_JOYBUTTONS] = { false };
+static u32 mouse_buttons = 0;
+static u32 last_mouse = VK_INVALID;
+static u32 last_joybutton = VK_INVALID;
+
+static int num_joy_axes = 0;
+static int num_joy_buttons = 0;
+static int num_joy_hats = 0;
+
+static inline void controller_add_binds(const u32 mask, const u32 *btns) {
+    for (u32 i = 0; i < MAX_BINDS; ++i) {
+        if (btns[i] >= VK_BASE_SDL_GAMEPAD && btns[i] <= VK_BASE_SDL_GAMEPAD + VK_SIZE) {
+            if (btns[i] >= VK_BASE_SDL_MOUSE && num_joy_binds < MAX_JOYBINDS) {
+                mouse_binds[num_mouse_binds][0] = btns[i] - VK_BASE_SDL_MOUSE;
+                mouse_binds[num_mouse_binds][1] = mask;
+                ++num_mouse_binds;
+            } else if (num_mouse_binds < MAX_JOYBINDS) {
+                joy_binds[num_joy_binds][0] = btns[i] - VK_BASE_SDL_GAMEPAD;
+                joy_binds[num_joy_binds][1] = mask;
+                ++num_joy_binds;
+            }
+        }
+    }
+}
+
+static void controller_sdl_bind(void) {
+    bzero(joy_binds, sizeof(joy_binds));
+    bzero(mouse_binds, sizeof(mouse_binds));
+    num_joy_binds = 0;
+    num_mouse_binds = 0;
+
+    controller_add_binds(A_BUTTON,     configKeyA);
+    controller_add_binds(B_BUTTON,     configKeyB);
+    controller_add_binds(Z_TRIG,       configKeyZ);
+    controller_add_binds(STICK_UP,     configKeyStickUp);
+    controller_add_binds(STICK_LEFT,   configKeyStickLeft);
+    controller_add_binds(STICK_DOWN,   configKeyStickDown);
+    controller_add_binds(STICK_RIGHT,  configKeyStickRight);
+    controller_add_binds(U_CBUTTONS,   configKeyCUp);
+    controller_add_binds(L_CBUTTONS,   configKeyCLeft);
+    controller_add_binds(D_CBUTTONS,   configKeyCDown);
+    controller_add_binds(R_CBUTTONS,   configKeyCRight);
+    controller_add_binds(L_TRIG,       configKeyL);
+    controller_add_binds(R_TRIG,       configKeyR);
+    controller_add_binds(START_BUTTON, configKeyStart);
+}
+
+static void controller_sdl_init(void) {
+    if (SDL_Init(SDL_INIT_JOYSTICK) != 0) {
+        fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
+        return;
+    }
+
+    if (SDL_NumJoysticks() > 0)
+        sdl_joy = SDL_JoystickOpen(0);
+
+    if (sdl_joy) {
+        num_joy_axes = SDL_JoystickNumAxes(sdl_joy);
+        num_joy_buttons = SDL_JoystickNumButtons(sdl_joy);
+        num_joy_hats = SDL_JoystickNumHats(sdl_joy);
+
+        for (int i = 0; i < MAX_AXES; ++i)
+            if (i >= num_joy_axes)
+                joy_axis_binds[i] = -1;
+    }
+
+#ifdef BETTERCAMERA
+    if (newcam_mouse == 1)
+        SDL_WM_GrabInput(SDL_GRAB_ON);
+    SDL_GetRelativeMouseState(&mouse_x, &mouse_y);
+#endif
+
+    controller_sdl_bind();
+
+    init_ok = true;
+}
+
+static inline void update_button(const int i, const bool new) {
+    const bool pressed = !joy_buttons[i] && new;
+    joy_buttons[i] = new;
+    if (pressed) last_joybutton = i;
+}
+
+static inline int16_t get_axis(const int i) {
+    if (joy_axis_binds[i] >= 0)
+        return SDL_JoystickGetAxis(sdl_joy, i);
+    else
+        return 0;
+}
+
+static void controller_sdl_read(OSContPad *pad) {
+    if (!init_ok) return;
+
+#ifdef BETTERCAMERA
+    if (newcam_mouse == 1 && sCurrPlayMode != 2)
+        SDL_WM_GrabInput(SDL_GRAB_ON);
+    else
+        SDL_WM_GrabInput(SDL_GRAB_OFF);
+    
+    u32 mouse = SDL_GetRelativeMouseState(&mouse_x, &mouse_y);
+
+    for (u32 i = 0; i < num_mouse_binds; ++i)
+        if (mouse & SDL_BUTTON(mouse_binds[i][0]))
+            pad->button |= mouse_binds[i][1];
+
+    // remember buttons that changed from 0 to 1
+    last_mouse = (mouse_buttons ^ mouse) & mouse;
+    mouse_buttons = mouse;
+#endif
+
+    if (!sdl_joy) return;
+
+    SDL_JoystickUpdate();
+
+    int16_t leftx = get_axis(JOY_AXIS_LEFTX);
+    int16_t lefty = get_axis(JOY_AXIS_LEFTY);
+    int16_t rightx = get_axis(JOY_AXIS_RIGHTX);
+    int16_t righty = get_axis(JOY_AXIS_RIGHTY);
+
+    int16_t ltrig = get_axis(JOY_AXIS_LTRIG);
+    int16_t rtrig = get_axis(JOY_AXIS_RTRIG);
+
+#ifdef TARGET_WEB
+    // Firefox has a bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1606562
+    // It sets down y to 32768.0f / 32767.0f, which is greater than the allowed 1.0f,
+    // which SDL then converts to a int16_t by multiplying by 32767.0f, which overflows into -32768.
+    // Maximum up will hence never become -32768 with the current version of SDL2,
+    // so this workaround should be safe in compliant browsers.
+    if (lefty == -32768) {
+        lefty = 32767;
+    }
+    if (righty == -32768) {
+        righty = 32767;
+    }
+#endif
+
+    for (int i = 0; i < num_joy_buttons; ++i) {
+        const bool new = SDL_JoystickGetButton(sdl_joy, i);
+        update_button(i, new);
+    }
+
+    update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig > AXIS_THRESHOLD);
+    update_button(VK_RTRIGGER - VK_BASE_SDL_GAMEPAD, rtrig > AXIS_THRESHOLD);
+
+    u32 buttons_down = 0;
+    for (u32 i = 0; i < num_joy_binds; ++i)
+        if (joy_buttons[joy_binds[i][0]])
+            buttons_down |= joy_binds[i][1];
+
+    pad->button |= buttons_down;
+
+    const u32 xstick = buttons_down & STICK_XMASK;
+    const u32 ystick = buttons_down & STICK_YMASK;
+    if (xstick == STICK_LEFT)
+        pad->stick_x = -128;
+    else if (xstick == STICK_RIGHT)
+        pad->stick_x = 127;
+    if (ystick == STICK_DOWN)
+        pad->stick_y = -128;
+    else if (ystick == STICK_UP)
+        pad->stick_y = 127;
+
+    if (rightx < -0x4000) pad->button |= L_CBUTTONS;
+    if (rightx > 0x4000) pad->button |= R_CBUTTONS;
+    if (righty < -0x4000) pad->button |= U_CBUTTONS;
+    if (righty > 0x4000) pad->button |= D_CBUTTONS;
+
+    uint32_t magnitude_sq = (uint32_t)(leftx * leftx) + (uint32_t)(lefty * lefty);
+    uint32_t stickDeadzoneActual = configStickDeadzone * DEADZONE_STEP;
+    if (magnitude_sq > (uint32_t)(stickDeadzoneActual * stickDeadzoneActual)) {
+        pad->stick_x = leftx / 0x100;
+        int stick_y = -lefty / 0x100;
+        pad->stick_y = stick_y == 128 ? 127 : stick_y;
+    }
+
+    magnitude_sq = (uint32_t)(rightx * rightx) + (uint32_t)(righty * righty);
+    stickDeadzoneActual = configStickDeadzone * DEADZONE_STEP;
+    if (magnitude_sq > (uint32_t)(stickDeadzoneActual * stickDeadzoneActual)) {
+        pad->ext_stick_x = rightx / 0x100;
+        int stick_y = -righty / 0x100;
+        pad->ext_stick_y = stick_y == 128 ? 127 : stick_y;
+    }
+}
+
+static void controller_sdl_rumble_play(f32 strength, f32 length) { }
+
+static void controller_sdl_rumble_stop(void) { }
+
+static u32 controller_sdl_rawkey(void) {
+    if (last_joybutton != VK_INVALID) {
+        const u32 ret = last_joybutton;
+        last_joybutton = VK_INVALID;
+        return ret;
+    }
+
+    for (int i = 0; i < MAX_MOUSEBUTTONS; ++i) {
+        if (last_mouse & SDL_BUTTON(i)) {
+            const u32 ret = VK_OFS_SDL_MOUSE + i;
+            last_mouse = 0;
+            return ret;
+        }
+    }
+    return VK_INVALID;
+}
+
+static void controller_sdl_shutdown(void) {
+    if (SDL_WasInit(SDL_INIT_JOYSTICK)) {
+        if (sdl_joy) {
+            SDL_JoystickClose(sdl_joy);
+            sdl_joy = NULL;
+        }
+        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+    }
+
+    init_ok = false;
+}
+
+struct ControllerAPI controller_sdl = {
+    VK_BASE_SDL_GAMEPAD,
+    controller_sdl_init,
+    controller_sdl_read,
+    controller_sdl_rawkey,
+    controller_sdl_rumble_play,
+    controller_sdl_rumble_stop,
+    controller_sdl_bind,
+    controller_sdl_shutdown
+};
+
+#endif // CAPI_SDL1

--- a/src/pc/controller/controller_sdl2.c
+++ b/src/pc/controller/controller_sdl2.c
@@ -13,7 +13,7 @@
 #include <ultra64.h>
 
 #include "controller_api.h"
-#include "controller_sdl2.h"
+#include "controller_sdl.h"
 #include "../configfile.h"
 #include "../platform.h"
 #include "../fs/fs.h"

--- a/src/pc/controller/controller_sdl2.c
+++ b/src/pc/controller/controller_sdl2.c
@@ -13,7 +13,7 @@
 #include <ultra64.h>
 
 #include "controller_api.h"
-#include "controller_sdl.h"
+#include "controller_sdl2.h"
 #include "../configfile.h"
 #include "../platform.h"
 #include "../fs/fs.h"

--- a/src/pc/discord/discordrpc.c
+++ b/src/pc/discord/discordrpc.c
@@ -188,7 +188,7 @@ static void set_state(void) {
         // when exiting a stage the act doesn't get reset
         if (gCurrActNum && gCurrCourseNum) {
             // any stage over 19 is a special stage without acts
-            if (gCurrCourseNum < 19) {
+            if (gCurrCourseNum <= COURSE_STAGES_MAX) {
                 void **actNameTbl;
 #ifndef VERSION_EU
                 actNameTbl = segmented_to_virtual(seg2_act_name_table);

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -19,13 +19,20 @@
 # include <GL/glew.h>
 #endif
 
-#include <SDL2/SDL.h>
-
 #define GL_GLEXT_PROTOTYPES 1
-#ifdef USE_GLES
-# include <SDL2/SDL_opengles2.h>
-#else
-# include <SDL2/SDL_opengl.h>
+
+#ifdef WAPI_SDL2
+# include <SDL2/SDL.h>
+# ifdef USE_GLES
+#  include <SDL2/SDL_opengles2.h>
+# else
+#  include <SDL2/SDL_opengl.h>
+# endif
+#elif defined(WAPI_SDL1)
+# include <SDL/SDL.h>
+# ifndef GLEW_STATIC
+#  include <SDL/SDL_opengl.h>
+# endif
 #endif
 
 #include "../platform.h"

--- a/src/pc/gfx/gfx_opengl_legacy.c
+++ b/src/pc/gfx/gfx_opengl_legacy.c
@@ -589,9 +589,6 @@ static void gfx_opengl_finish_render(void) {
 static void gfx_opengl_shutdown(void) {
 }
 
-static void gfx_opengl_shutdown(void) {
-}
-
 struct GfxRenderingAPI gfx_opengl_api = {
     gfx_opengl_z_is_from_0_to_1,
     gfx_opengl_unload_shader,

--- a/src/pc/gfx/gfx_opengl_legacy.c
+++ b/src/pc/gfx/gfx_opengl_legacy.c
@@ -15,15 +15,22 @@
 # define FOR_WINDOWS 0
 #endif
 
-#include <SDL2/SDL.h>
-
 #if FOR_WINDOWS || defined(OSX_BUILD)
 # define GLEW_STATIC
 # include <GL/glew.h>
 #endif
 
 #define GL_GLEXT_PROTOTYPES 1
-#include <SDL2/SDL_opengl.h>
+
+#ifdef WAPI_SDL2
+# include <SDL2/SDL.h>
+# include <SDL2/SDL_opengl.h>
+#elif defined(WAPI_SDL1)
+# include <SDL/SDL.h>
+# ifndef GLEW_STATIC
+#  include <SDL/SDL_opengl.h>
+# endif
+#endif
 
 // redefine this if using a different GL loader
 #define mglGetProcAddress(name) SDL_GL_GetProcAddress(name)

--- a/src/pc/gfx/gfx_opengl_legacy.c
+++ b/src/pc/gfx/gfx_opengl_legacy.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <unistd.h>
 
 #ifndef _LANGUAGE_C
 # define _LANGUAGE_C
@@ -32,39 +33,10 @@
 # endif
 #endif
 
-// redefine this if using a different GL loader
-#define mglGetProcAddress(name) SDL_GL_GetProcAddress(name)
-
-// we'll define and load it manually in init, just in case
-typedef void (*PFNMGLFOGCOORDPOINTERPROC)(GLenum type, GLsizei stride, const void *pointer);
-static PFNMGLFOGCOORDPOINTERPROC mglFogCoordPointer = NULL;
-
-// since these can have different names, might as well redefine them to a single one
-#undef GL_FOG_COORD_SRC
-#undef GL_FOG_COORD
-#undef GL_FOG_COORD_ARRAY
-#define GL_FOG_COORD_SRC 0x8450
-#define GL_FOG_COORD 0x8451
-#define GL_FOG_COORD_ARRAY 0x8457
-
 #include "../platform.h"
 #include "gfx_cc.h"
 #include "gfx_rendering_api.h"
 #include "macros.h"
-
-enum MixFlags {
-    SH_MF_OVERRIDE_ALPHA = 1,
-
-    SH_MF_MULTIPLY = 2,
-    SH_MF_MIX = 4,
-    SH_MF_SINGLE = 8,
-
-    SH_MF_MULTIPLY_ALPHA = 16,
-    SH_MF_MIX_ALPHA = 32,
-    SH_MF_SINGLE_ALPHA = 64,
-
-    SH_MF_INPUT_ALPHA = 128,
-};
 
 enum MixType {
     SH_MT_NONE,
@@ -76,16 +48,28 @@ enum MixType {
 };
 
 struct ShaderProgram {
+    bool enabled;
     uint32_t shader_id;
+    struct CCFeatures cc;
     enum MixType mix;
-    uint32_t mix_flags;
     bool texture_used[2];
+    int texture_ord[2];
     int num_inputs;
+};
+
+struct SamplerState {
+    GLenum min_filter;
+    GLenum mag_filter;
+    GLenum wrap_s;
+    GLenum wrap_t;
+    GLuint tex;
 };
 
 static struct ShaderProgram shader_program_pool[64];
 static uint8_t shader_program_pool_size;
 static struct ShaderProgram *cur_shader = NULL;
+
+static struct SamplerState tmu_state[2];
 
 static const float *cur_buf = NULL;
 static const float *cur_fog_ofs = NULL;
@@ -93,102 +77,92 @@ static size_t cur_buf_size = 0;
 static size_t cur_buf_num_tris = 0;
 static size_t cur_buf_stride = 0;
 static bool gl_blend = false;
-static bool gl_adv_fog = false;
 
+static bool gl_npot = false;
+static bool gl_multitexture = false;
+
+static void *scale_buf = NULL;
+static int scale_buf_size = 0;
+
+static float c_mix[] = { 0.f, 0.f, 0.f, 1.f };
+static float c_invmix[] = { 1.f, 1.f, 1.f, 1.f };
 static const float c_white[] = { 1.f, 1.f, 1.f, 1.f };
+
+// from https://github.com/z2442/sm64-port
+
+static void resample_32bit(const uint32_t *in, const int inwidth, const int inheight, uint32_t *out, const int outwidth, const int outheight) {
+  int i, j;
+  const uint32_t *inrow;
+  uint32_t frac, fracstep;
+
+  fracstep = inwidth * 0x10000 / outwidth;
+  for (i = 0; i < outheight; i++, out += outwidth) {
+    inrow = in + inwidth * (i * inheight / outheight);
+    frac = fracstep >> 1;
+    for (j = 0; j < outwidth; j += 4) {
+      out[j] = inrow[frac >> 16];
+      frac += fracstep;
+      out[j + 1] = inrow[frac >> 16];
+      frac += fracstep;
+      out[j + 2] = inrow[frac >> 16];
+      frac += fracstep;
+      out[j + 3] = inrow[frac >> 16];
+      frac += fracstep;
+    }
+  }
+}
+
+static inline uint32_t next_pot(uint32_t v) {
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v++;
+    return v;
+}
+
+static inline uint32_t is_pot(const uint32_t v) {
+    return (v & (v - 1)) == 0;
+}
 
 static bool gfx_opengl_z_is_from_0_to_1(void) {
     return false;
 }
 
-#define TEXENV_COMBINE_ON() glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE)
-#define TEXENV_COMBINE_OFF() glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE)
-
-#define TEXENV_COMBINE_OP(num, cval, aval) \
-    do { \
-        glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND ## num ## _RGB, cval); \
-        glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND ## num ## _ALPHA, aval); \
-    } while (0)
-
-#define TEXENV_COMBINE_SET1(what, mode, val) \
-    do { \
-        glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ ## what, mode); \
-        glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ ## what, val); \
-    } while (0)
-
-#define TEXENV_COMBINE_SET2(what, mode, val1, val2) \
-    do { \
-        glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ ## what, mode); \
-        glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ ## what, val1); \
-        glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_ ## what, val2); \
-    } while (0)
-
-#define TEXENV_COMBINE_SET3(what, mode, val1, val2, val3) \
-    do { \
-        glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ ## what, mode); \
-        glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ ## what, val1); \
-        glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_ ## what, val2); \
-        glTexEnvi(GL_TEXTURE_ENV, GL_SRC2_ ## what, val3); \
-    } while (0)
-
-static inline void texenv_set_texture_color(struct ShaderProgram *prg) {
-    glActiveTexture(GL_TEXTURE0);
-
-    if (prg->mix_flags & SH_MF_OVERRIDE_ALPHA) {
-        TEXENV_COMBINE_ON();
-        if (prg->mix_flags & SH_MF_SINGLE_ALPHA) {
-            if (prg->mix_flags & SH_MF_MULTIPLY) {
-                // keep the alpha but modulate the color
-                const GLenum alphasrc = (prg->mix_flags & SH_MF_INPUT_ALPHA) ? GL_PRIMARY_COLOR : GL_TEXTURE;
-                TEXENV_COMBINE_SET2(RGB, GL_MODULATE, GL_TEXTURE, GL_PRIMARY_COLOR);
-                TEXENV_COMBINE_SET1(ALPHA, GL_REPLACE, alphasrc);
-            } else {
-                // somehow makes it keep the color while taking the alpha from primary color
-                TEXENV_COMBINE_SET1(RGB, GL_REPLACE, GL_TEXTURE);
-            }
-        } else { // if (prg->mix_flags & SH_MF_SINGLE) {
-            if (prg->mix_flags & SH_MF_MULTIPLY_ALPHA) {
-                // modulate the alpha but keep the color
-                TEXENV_COMBINE_SET2(ALPHA, GL_MODULATE, GL_TEXTURE, GL_PRIMARY_COLOR);
-                TEXENV_COMBINE_SET1(RGB, GL_REPLACE, GL_TEXTURE);
-            } else {
-                // somehow makes it keep the alpha
-                TEXENV_COMBINE_SET1(ALPHA, GL_REPLACE, GL_TEXTURE);
-            }
-        }
-        // TODO: MIX and the other one
-    } else if (prg->mix_flags & SH_MF_MULTIPLY) {
-        // TODO: is this right?
-        TEXENV_COMBINE_OFF();
-    } else if (prg->mix_flags & SH_MF_MIX) {
-        TEXENV_COMBINE_ON();
-        // HACK: determine this using flags and not this crap
-        if (prg->num_inputs > 1) {
-            // out.rgb = mix(color0.rgb, color1.rgb, texel0.rgb);
-            // no color1 tho, so mix with white (texenv color is set in init())
-            TEXENV_COMBINE_OP(2, GL_SRC_COLOR, GL_SRC_ALPHA);
-            TEXENV_COMBINE_SET3(RGB, GL_INTERPOLATE, GL_CONSTANT, GL_PRIMARY_COLOR, GL_TEXTURE);
-            TEXENV_COMBINE_SET1(ALPHA, GL_REPLACE, GL_CONSTANT);
-        } else {
-            // out.rgb = mix(color0.rgb, texel0.rgb, texel0.a);
-            TEXENV_COMBINE_OP(2, GL_SRC_ALPHA, GL_SRC_ALPHA);
-            TEXENV_COMBINE_SET3(RGB, GL_INTERPOLATE, GL_TEXTURE, GL_PRIMARY_COLOR, GL_TEXTURE);
-        }
-    } else {
-        TEXENV_COMBINE_OFF();
-    }
+static inline GLenum texenv_set_color(UNUSED struct ShaderProgram *prg) {
+    return GL_MODULATE;
 }
 
-static inline void texenv_set_texture_texture(UNUSED struct ShaderProgram *prg) {
-    glActiveTexture(GL_TEXTURE0);
-    TEXENV_COMBINE_OFF();
-    glActiveTexture(GL_TEXTURE1);
-    TEXENV_COMBINE_ON();
-    // out.rgb = mix(texel0.rgb, texel1.rgb, color0.rgb);
-    TEXENV_COMBINE_OP(2, GL_SRC_COLOR, GL_SRC_ALPHA);
-    TEXENV_COMBINE_SET3(RGB, GL_INTERPOLATE, GL_PREVIOUS, GL_TEXTURE, GL_PRIMARY_COLOR);
-    // out.a = texel0.a;
-    TEXENV_COMBINE_SET1(ALPHA, GL_REPLACE, GL_PREVIOUS);
+static inline GLenum texenv_set_texture(UNUSED struct ShaderProgram *prg) {
+    return GL_MODULATE;
+}
+
+static inline GLenum texenv_set_texture_color(struct ShaderProgram *prg) {
+    GLenum mode;
+
+    // HACK: lord forgive me for this, but this is easier
+
+    switch (prg->shader_id) {
+        case 0x0000038D: // mario's eyes
+        case 0x01045A00: // peach letter
+        case 0x01200A00: // intro copyright fade in
+            mode = GL_DECAL;
+            break;
+        case 0x00000551: // goddard
+            mode = GL_BLEND;
+            break;
+        default:
+            mode = GL_MODULATE;
+            break;
+    }
+
+    return mode;
+}
+
+static inline GLenum texenv_set_texture_texture(UNUSED struct ShaderProgram *prg) {
+    return GL_MODULATE;
 }
 
 static void gfx_opengl_apply_shader(struct ShaderProgram *prg) {
@@ -199,31 +173,19 @@ static void gfx_opengl_apply_shader(struct ShaderProgram *prg) {
     ofs += 4;
 
     // have texture(s), specify same texcoords for every active texture
-    for (int i = 0; i < 2; ++i) {
-        if (prg->texture_used[i]) {
-            glEnable(GL_TEXTURE0 + i);
-            glClientActiveTexture(GL_TEXTURE0 + i);
-            glActiveTexture(GL_TEXTURE0 + i);
-            glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-            glTexCoordPointer(2, GL_FLOAT, cur_buf_stride, ofs);
-            glEnable(GL_TEXTURE_2D);
-            ofs += 2;
-        }
+    if (prg->texture_used[0] || prg->texture_used[1]) {
+        glEnable(GL_TEXTURE_2D);
+        glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+        glTexCoordPointer(2, GL_FLOAT, cur_buf_stride, ofs);
+        ofs += 2;
+    } else {
+        glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+        glDisable(GL_TEXTURE_2D);
     }
 
     if (prg->shader_id & SHADER_OPT_FOG) {
-        // fog requested, we can deal with it in one of two ways
-        if (gl_adv_fog) {
-            // if GL_EXT_fog_coord is available, use the provided fog factor as scaled depth for GL fog
-            const float fogrgb[] = { ofs[0], ofs[1], ofs[2] };
-            glEnable(GL_FOG);
-            glFogfv(GL_FOG_COLOR, fogrgb); // color is the same for all verts, only intensity is different
-            glEnableClientState(GL_FOG_COORD_ARRAY);
-            mglFogCoordPointer(GL_FLOAT, cur_buf_stride, ofs + 3); // point it to alpha, which is fog factor
-        } else {
-            // if there's no fog coords available, blend it on top of normal tris later
-            cur_fog_ofs = ofs;
-        }
+        // blend it on top of normal tris later
+        cur_fog_ofs = ofs;
         ofs += 4;
     }
 
@@ -232,127 +194,102 @@ static void gfx_opengl_apply_shader(struct ShaderProgram *prg) {
         // TODO: more than one color (maybe glSecondaryColorPointer?)
         // HACK: if there's a texture and two colors, one of them is likely for speculars or some shit (see mario head)
         //       if there's two colors but no texture, the real color is likely the second one
-        const int hack = (prg->num_inputs > 1) * (4 - (int)prg->texture_used[0]);
-        glEnableClientState(GL_COLOR_ARRAY);
-        glColorPointer(4, GL_FLOAT, cur_buf_stride, ofs + hack);
-        ofs += 4 * prg->num_inputs;
+        // HACKHACK: alpha is 0 in the transition shader (0x01A00045), maybe figure out the flags instead
+        const int vlen = (prg->cc.opt_alpha && prg->shader_id != 0x01A00045) ? 4 : 3;
+        const int hack = vlen * (prg->num_inputs > 1);
+
+        if (prg->texture_used[1] && prg->cc.do_mix[0]) {
+            // HACK: when two textures are mixed by vertex color, store the color
+            //       it will be used later when rendering two texture passes
+            c_mix[0] = *(ofs + hack + 0);
+            c_mix[1] = *(ofs + hack + 1);
+            c_mix[2] = *(ofs + hack + 2);
+            c_invmix[0] = 1.f - c_mix[0];
+            c_invmix[1] = 1.f - c_mix[1];
+            c_invmix[2] = 1.f - c_mix[2];
+            glDisableClientState(GL_COLOR_ARRAY);
+            glColor3f(c_mix[0], c_mix[1], c_mix[2]);
+        } else {
+            // otherwise use vertex colors as normal
+            glEnableClientState(GL_COLOR_ARRAY);
+            glColorPointer(vlen, GL_FLOAT, cur_buf_stride, ofs + hack);
+        }
+
+        ofs += prg->num_inputs * vlen;
+    } else {
+        glDisableClientState(GL_COLOR_ARRAY);
     }
 
-    if (prg->shader_id & SHADER_OPT_TEXTURE_EDGE) {
-        // (horrible) alpha discard
-        glEnable(GL_ALPHA_TEST);
-        glAlphaFunc(GL_GREATER, 0.3f);
-    }
+    if (!prg->enabled) {
+        // we only need to do this once
+        prg->enabled = true;
 
-    // configure formulae
-    switch (prg->mix) {
-        case SH_MT_TEXTURE:
-            glActiveTexture(GL_TEXTURE0);
-            TEXENV_COMBINE_OFF();
-            break;
+        if (prg->shader_id & SHADER_OPT_TEXTURE_EDGE) {
+            // (horrible) alpha discard
+            glEnable(GL_ALPHA_TEST);
+            glAlphaFunc(GL_GREATER, 0.666f);
+        } else {
+            glDisable(GL_ALPHA_TEST);
+        }
 
-        case SH_MT_TEXTURE_COLOR:
-            texenv_set_texture_color(prg);
-            break;
-
-        case SH_MT_TEXTURE_TEXTURE:
-            texenv_set_texture_texture(prg);
-            break;
-
-        default:
-            break;
+        // configure texenv
+        GLenum mode;
+        switch (prg->mix) {
+            case SH_MT_TEXTURE:         mode = texenv_set_texture(prg); break;
+            case SH_MT_TEXTURE_TEXTURE: mode = texenv_set_texture_texture(prg); break;
+            case SH_MT_TEXTURE_COLOR:   mode = texenv_set_texture_color(prg); break;
+            default:                    mode = texenv_set_color(prg); break;
+        }
+        glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, mode);
     }
 }
 
 static void gfx_opengl_unload_shader(struct ShaderProgram *old_prg) {
-    if (cur_shader == old_prg || old_prg == NULL)
+    if (cur_shader && (cur_shader == old_prg || !old_prg)) {
+        cur_shader->enabled = false;
         cur_shader = NULL;
-
-    glClientActiveTexture(GL_TEXTURE0);
-    glActiveTexture(GL_TEXTURE0);
-    glDisable(GL_TEXTURE_2D);
-    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-
-    glClientActiveTexture(GL_TEXTURE1);
-    glActiveTexture(GL_TEXTURE1);
-    glDisable(GL_TEXTURE_2D);
-    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-
-    glDisable(GL_TEXTURE1);
-    glDisable(GL_TEXTURE0);
-    glDisable(GL_TEXTURE_2D);
-    glDisable(GL_ALPHA_TEST);
-    glDisable(GL_FOG);
+    }
     cur_fog_ofs = NULL; // clear fog colors
-
-    glDisableClientState(GL_COLOR_ARRAY);
-    if (gl_adv_fog) glDisableClientState(GL_FOG_COORD_ARRAY);
 }
 
 static void gfx_opengl_load_shader(struct ShaderProgram *new_prg) {
     cur_shader = new_prg;
-    // gfx_opengl_apply_shader(cur_shader);
+    if (cur_shader)
+        cur_shader->enabled = false;
 }
 
 static struct ShaderProgram *gfx_opengl_create_and_load_new_shader(uint32_t shader_id) {
-    uint8_t c[2][4];
-    for (int i = 0; i < 4; i++) {
-        c[0][i] = (shader_id >> (i * 3)) & 7;
-        c[1][i] = (shader_id >> (12 + i * 3)) & 7;
-    }
-
-    bool used_textures[2] = {0, 0};
-    int num_inputs = 0;
-    for (int i = 0; i < 2; i++) {
-        for (int j = 0; j < 4; j++) {
-            if (c[i][j] >= SHADER_INPUT_1 && c[i][j] <= SHADER_INPUT_4) {
-                if (c[i][j] > num_inputs) {
-                    num_inputs = c[i][j];
-                }
-            }
-            if (c[i][j] == SHADER_TEXEL0 || c[i][j] == SHADER_TEXEL0A) {
-                used_textures[0] = true;
-            }
-            if (c[i][j] == SHADER_TEXEL1) {
-                used_textures[1] = true;
-            }
-        }
-    }
-
-    const bool color_alpha_same = (shader_id & 0xfff) == ((shader_id >> 12) & 0xfff);
-    const bool do_multiply[2] = {c[0][1] == 0 && c[0][3] == 0, c[1][1] == 0 && c[1][3] == 0};
-    const bool do_mix[2] = {c[0][1] == c[0][3], c[1][1] == c[1][3]};
-    const bool do_single[2] = {c[0][2] == 0, c[1][2] == 0};
+    struct CCFeatures ccf;
+    gfx_cc_get_features(shader_id, &ccf);
 
     struct ShaderProgram *prg = &shader_program_pool[shader_program_pool_size++];
 
     prg->shader_id = shader_id;
-    prg->num_inputs = num_inputs;
-    prg->texture_used[0] = used_textures[0];
-    prg->texture_used[1] = used_textures[1];
+    prg->cc = ccf;
+    prg->num_inputs = ccf.num_inputs;
+    prg->texture_used[0] = ccf.used_textures[0];
+    prg->texture_used[1] = ccf.used_textures[1];
 
-    if (used_textures[0] && used_textures[1])
+    if (ccf.used_textures[0] && ccf.used_textures[1]) {
         prg->mix = SH_MT_TEXTURE_TEXTURE;
-    else if (used_textures[0] && num_inputs)
+        if (ccf.do_single[1]) {
+            prg->texture_ord[0] = 1;
+            prg->texture_ord[1] = 0;
+        } else {
+            prg->texture_ord[0] = 0;
+            prg->texture_ord[1] = 1;
+        }
+    } else if (ccf.used_textures[0] && ccf.num_inputs) {
         prg->mix = SH_MT_TEXTURE_COLOR;
-    else if (used_textures[0])
+    } else if (ccf.used_textures[0]) {
         prg->mix = SH_MT_TEXTURE;
-    else if (num_inputs > 1)
+    } else if (ccf.num_inputs > 1) {
         prg->mix = SH_MT_COLOR_COLOR;
-    else if (num_inputs)
+    } else if (ccf.num_inputs) {
         prg->mix = SH_MT_COLOR;
-
-    if (do_single[0]) prg->mix_flags |= SH_MF_SINGLE;
-    if (do_multiply[0]) prg->mix_flags |= SH_MF_MULTIPLY;
-    if (do_mix[0]) prg->mix_flags |= SH_MF_MIX;
-
-    if (!color_alpha_same && (shader_id & SHADER_OPT_ALPHA)) {
-        prg->mix_flags |= SH_MF_OVERRIDE_ALPHA;
-        if (do_single[1]) prg->mix_flags |= SH_MF_SINGLE_ALPHA;
-        if (do_multiply[1]) prg->mix_flags |= SH_MF_MULTIPLY_ALPHA;
-        if (do_mix[1]) prg->mix_flags |= SH_MF_MIX_ALPHA;
-        if (c[1][3] < SHADER_TEXEL0) prg->mix_flags |= SH_MF_INPUT_ALPHA;
     }
+
+    prg->enabled = false;
 
     gfx_opengl_load_shader(prg);
 
@@ -360,11 +297,9 @@ static struct ShaderProgram *gfx_opengl_create_and_load_new_shader(uint32_t shad
 }
 
 static struct ShaderProgram *gfx_opengl_lookup_shader(uint32_t shader_id) {
-    for (size_t i = 0; i < shader_program_pool_size; i++) {
-        if (shader_program_pool[i].shader_id == shader_id) {
+    for (size_t i = 0; i < shader_program_pool_size; i++)
+        if (shader_program_pool[i].shader_id == shader_id)
             return &shader_program_pool[i];
-        }
-    }
     return NULL;
 }
 
@@ -381,35 +316,72 @@ static GLuint gfx_opengl_new_texture(void) {
 }
 
 static void gfx_opengl_select_texture(int tile, GLuint texture_id) {
-    glActiveTexture(GL_TEXTURE0 + tile);
+    tmu_state[tile].tex = texture_id; // remember this for multitexturing later
     glBindTexture(GL_TEXTURE_2D, texture_id);
 }
 
-static void gfx_opengl_upload_texture(uint8_t *rgba32_buf, int width, int height) {
+static inline void *gfx_opengl_scale_texture(const uint8_t *data, const int w, const int h, const int to_w, const int to_h) {
+    const int psize = to_w * to_h * 4;
+
+    // realloc scale buffer if it's too small
+    if (psize > scale_buf_size) {
+        scale_buf = realloc(scale_buf, psize);
+        if (!scale_buf) sys_fatal("Out of memory allocating NPOT scale buffer\n");
+        scale_buf_size = psize;
+    }
+
+    resample_32bit((const uint32_t *)data, w, h, scale_buf, to_w, to_h);
+
+    return scale_buf;
+}
+
+static void gfx_opengl_upload_texture(const uint8_t *rgba32_buf, int width, int height) {
+    if (!gl_npot) {
+        // we don't support non power of two textures, scale to next power of two if necessary
+        if (!is_pot(width) || !is_pot(height)) {
+            const int pwidth = next_pot(width);
+            const int pheight = next_pot(height);
+            rgba32_buf = gfx_opengl_scale_texture(rgba32_buf, width, height, pwidth, pheight);
+            width = pwidth;
+            height = pheight;
+        }
+    }
+
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
 }
 
-static uint32_t gfx_cm_to_opengl(uint32_t val) {
-    if (val & G_TX_CLAMP)
-        return GL_CLAMP_TO_EDGE;
+static inline GLenum gfx_cm_to_opengl(uint32_t val) {
+    if (val & G_TX_CLAMP) return GL_CLAMP_TO_EDGE;
     return (val & G_TX_MIRROR) ? GL_MIRRORED_REPEAT : GL_REPEAT;
+}
+
+static inline void gfx_opengl_apply_tmu_state(const int tile) {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, tmu_state[tile].min_filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, tmu_state[tile].mag_filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, tmu_state[tile].wrap_s);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, tmu_state[tile].wrap_t);
 }
 
 static void gfx_opengl_set_sampler_parameters(int tile, bool linear_filter, uint32_t cms, uint32_t cmt) {
     const GLenum filter = linear_filter ? GL_LINEAR : GL_NEAREST;
-    glActiveTexture(GL_TEXTURE0 + tile);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, gfx_cm_to_opengl(cms));
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, gfx_cm_to_opengl(cmt));
+
+    const GLenum wrap_s = gfx_cm_to_opengl(cms);
+    const GLenum wrap_t = gfx_cm_to_opengl(cmt);
+
+    tmu_state[tile].min_filter = filter;
+    tmu_state[tile].mag_filter = filter;
+    tmu_state[tile].wrap_s = wrap_s;
+    tmu_state[tile].wrap_t = wrap_t;
+
+    // set state for the first texture right away
+    if (!tile) gfx_opengl_apply_tmu_state(tile);
 }
 
 static void gfx_opengl_set_depth_test(bool depth_test) {
-    if (depth_test) {
+    if (depth_test)
         glEnable(GL_DEPTH_TEST);
-    } else {
+    else
         glDisable(GL_DEPTH_TEST);
-    }
 }
 
 static void gfx_opengl_set_depth_mask(bool z_upd) {
@@ -436,26 +408,19 @@ static void gfx_opengl_set_scissor(int x, int y, int width, int height) {
 
 static void gfx_opengl_set_use_alpha(bool use_alpha) {
     gl_blend = use_alpha;
-    if (use_alpha) {
+    if (use_alpha)
         glEnable(GL_BLEND);
-    } else {
+    else
         glDisable(GL_BLEND);
-    }
 }
 
 // draws the same triangles as plain fog color + fog intensity as alpha
 // on top of the normal tris and blends them to achieve sort of the same effect
 // as fog would
-static inline void gfx_opengl_blend_fog_tris(void) {
-    // if a texture was used, replace it with fog color instead, but still keep the alpha
-    if (cur_shader->texture_used[0]) {
-        glActiveTexture(GL_TEXTURE0);
-        TEXENV_COMBINE_ON();
-        // out.rgb = input0.rgb
-        TEXENV_COMBINE_SET1(RGB, GL_REPLACE, GL_PRIMARY_COLOR);
-        // out.a = texel0.a * input0.a
-        TEXENV_COMBINE_SET2(ALPHA, GL_MODULATE, GL_TEXTURE, GL_PRIMARY_COLOR);
-    }
+static inline void gfx_opengl_pass_fog(void) {
+    // if texturing is enabled, disable it, since we're blending colors
+    if (cur_shader->texture_used[0] || cur_shader->texture_used[1])
+        glDisable(GL_TEXTURE_2D);
 
     glEnableClientState(GL_COLOR_ARRAY); // enable color array temporarily
     glColorPointer(4, GL_FLOAT, cur_buf_stride, cur_fog_ofs); // set fog colors as primary colors
@@ -467,11 +432,38 @@ static inline void gfx_opengl_blend_fog_tris(void) {
     glDepthFunc(GL_LESS); // set back to default
     if (!gl_blend) glDisable(GL_BLEND); // disable blending if it was disabled
     glDisableClientState(GL_COLOR_ARRAY); // will get reenabled later anyway
+
+    // if texturing was enabled, re-enable it
+    if (cur_shader->texture_used[0] || cur_shader->texture_used[1])
+        glEnable(GL_TEXTURE_2D);
+}
+
+// this assumes the two textures are combined like so:
+// result = mix(tex0.rgb, tex1.rgb, vertex.rgb)
+static inline void gfx_opengl_pass_mix_texture(void) {
+    // set second texture
+    glBindTexture(GL_TEXTURE_2D, tmu_state[cur_shader->texture_ord[1]].tex);
+    gfx_opengl_apply_tmu_state(cur_shader->texture_ord[1]);
+
+    if (!gl_blend) glEnable(GL_BLEND); // enable blending temporarily
+    glBlendFunc(GL_ONE, GL_ONE); // additive blending
+    glDepthFunc(GL_LEQUAL); // Z is the same as the base triangles
+
+    // draw the same triangles, but with the inverse of the mix color
+    glColor3f(c_invmix[0], c_invmix[1], c_invmix[2]);
+    glDrawArrays(GL_TRIANGLES, 0, 3 * cur_buf_num_tris);
+    glColor3f(1.f, 1.f, 1.f); // reset color
+
+    glDepthFunc(GL_LESS); // set back to default
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // same here
+    if (!gl_blend) glDisable(GL_BLEND); // disable blending if it was disabled
+
+    // set old texture
+    glBindTexture(GL_TEXTURE_2D, tmu_state[cur_shader->texture_ord[0]].tex);
+    gfx_opengl_apply_tmu_state(cur_shader->texture_ord[0]);
 }
 
 static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_t buf_vbo_num_tris) {
-    //printf("flushing %d tris\n", buf_vbo_num_tris);
-
     cur_buf = buf_vbo;
     cur_buf_size = buf_vbo_len * 4;
     cur_buf_num_tris = buf_vbo_num_tris;
@@ -479,10 +471,17 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
 
     gfx_opengl_apply_shader(cur_shader);
 
+    // if there's two textures, set primary texture first
+    if (cur_shader->texture_used[1])
+        glBindTexture(GL_TEXTURE_2D, tmu_state[cur_shader->texture_ord[0]].tex);
+
     glDrawArrays(GL_TRIANGLES, 0, 3 * cur_buf_num_tris);
 
+    // if there's two textures, draw polys with the second texture
+    if (cur_shader->texture_used[1]) gfx_opengl_pass_mix_texture();
+
     // cur_fog_ofs is only set if GL_EXT_fog_coord isn't used
-    if (cur_fog_ofs) gfx_opengl_blend_fog_tris();
+    if (cur_fog_ofs) gfx_opengl_pass_fog();
 }
 
 static inline bool gl_check_ext(const char *name) {
@@ -492,7 +491,7 @@ static inline bool gl_check_ext(const char *name) {
         extstr = (const char *)glGetString(GL_EXTENSIONS);
 
     if (!strstr(extstr, name)) {
-        fprintf(stderr, "GL extension not supported: %s\n", name);
+        printf("GL extension not supported: %s\n", name);
         return false;
     }
 
@@ -526,54 +525,34 @@ static void gfx_opengl_init(void) {
     int vmajor, vminor;
     bool is_es = false;
     gl_get_version(&vmajor, &vminor, &is_es);
-    if (vmajor < 2 && vminor < 2 && !is_es)
-        sys_fatal("OpenGL 1.2+ is required.\nReported version: %s%d.%d", is_es ? "ES" : "", vmajor, vminor);
+    if ((vmajor < 2 && vminor < 1) || is_es)
+        sys_fatal("OpenGL 1.1+ is required.\nReported version: %s%d.%d\n", is_es ? "ES" : "", vmajor, vminor);
 
-    // check extensions that we need
-    const bool supported =
-        gl_check_ext("GL_ARB_multitexture") &&
-        gl_check_ext("GL_ARB_texture_env_combine");
-
-    if (!supported)
-        sys_fatal("required GL extensions are not supported");
-
-    gl_adv_fog = false;
-
-    // check whether we can use advanced fog shit
-    const bool fog_ext =
-        vmajor > 1 || vminor > 3 ||
-        gl_check_ext("GL_EXT_fog_coord") ||
-        gl_check_ext("GL_ARB_fog_coord");
-
-    if (fog_ext) {
-        // try to load manually, as this might be an extension, and even then the ext list may lie
-        mglFogCoordPointer = mglGetProcAddress("glFogCoordPointer");
-        if (!mglFogCoordPointer) mglFogCoordPointer = mglGetProcAddress("glFogCoordPointerEXT");
-        if (!mglFogCoordPointer) mglFogCoordPointer = mglGetProcAddress("glFogCoordPointerARB");
-        if (!mglFogCoordPointer)
-            printf("glFogCoordPointer is not actually available, it won't be used.\n");
-        else
-            gl_adv_fog = true; // appears to be all good
+    // check if we support non power of two textures
+    gl_npot = gl_check_ext("GL_ARB_texture_non_power_of_two");
+    if (!gl_npot) {
+        // don't support NPOT textures, prepare buffer for rescaling
+        // this will be realloc'd as necessary
+        scale_buf_size = 64 * 64 * 4;
+        scale_buf = malloc(scale_buf_size);
+        if (!scale_buf) sys_fatal("Out of memory allocating for NPOT scale buffer\n");
     }
+
+    // check if we support multitexturing
+    gl_multitexture = vmajor > 1 || vminor > 2 || gl_check_ext("GL_ARB_multitexture");
 
     printf("GL_VERSION = %s\n", glGetString(GL_VERSION));
     printf("GL_EXTENSIONS =\n%s\n", glGetString(GL_EXTENSIONS));
 
-    if (gl_adv_fog) {
-        // set fog params, they never change
-        printf("GL_EXT_fog_coord available, using that for fog\n");
-        glFogi(GL_FOG_COORD_SRC, GL_FOG_COORD);
-        glFogi(GL_FOG_MODE, GL_LINEAR);
-        glFogf(GL_FOG_START, 0.0f);
-        glFogf(GL_FOG_END, 1.0f);
-    }
-
     // these also never change
+    glDisable(GL_LIGHTING);
+    glDisable(GL_CULL_FACE);
+    // glDisable(GL_DITHER);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
     glEnableClientState(GL_VERTEX_ARRAY);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glTexEnvfv(GL_TEXTURE_ENV, GL_TEXTURE_ENV_COLOR, c_white);
-    TEXENV_COMBINE_OP(0, GL_SRC_COLOR, GL_SRC_ALPHA);
-    TEXENV_COMBINE_OP(1, GL_SRC_COLOR, GL_SRC_ALPHA);
 }
 
 static void gfx_opengl_on_resize(void) {

--- a/src/pc/gfx/gfx_opengl_legacy.c
+++ b/src/pc/gfx/gfx_opengl_legacy.c
@@ -132,11 +132,11 @@ static bool gfx_opengl_z_is_from_0_to_1(void) {
 }
 
 static inline GLenum texenv_set_color(UNUSED struct ShaderProgram *prg) {
-    return GL_MODULATE;
+    return GL_REPLACE;
 }
 
 static inline GLenum texenv_set_texture(UNUSED struct ShaderProgram *prg) {
-    return GL_MODULATE;
+    return GL_REPLACE;
 }
 
 static inline GLenum texenv_set_texture_color(struct ShaderProgram *prg) {

--- a/src/pc/gfx/gfx_sdl1.c
+++ b/src/pc/gfx/gfx_sdl1.c
@@ -1,0 +1,280 @@
+#ifdef WAPI_SDL1
+
+#ifdef __MINGW32__
+#define FOR_WINDOWS 1
+#else
+#define FOR_WINDOWS 0
+#endif
+
+#include <SDL/SDL.h>
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "gfx_window_manager_api.h"
+#include "gfx_screen_config.h"
+#include "../pc_main.h"
+#include "../configfile.h"
+#include "../cliopts.h"
+#include "../platform.h"
+
+#include "src/pc/controller/controller_keyboard.h"
+
+// TODO: figure out if this shit even works
+#ifdef VERSION_EU
+# define FRAMERATE 25
+#else
+# define FRAMERATE 30
+#endif
+
+static int inverted_scancode_table[512];
+
+static kb_callback_t kb_key_down = NULL;
+static kb_callback_t kb_key_up = NULL;
+static void (*kb_all_keys_up)(void) = NULL;
+
+// time between consequtive game frames
+static const int frame_time = 1000 / FRAMERATE;
+
+static int desktop_w = 640;
+static int desktop_h = 480;
+static int desktop_bpp = 24;
+
+static int window_w = 0;
+static int window_h = 0;
+
+const SDLKey windows_scancode_table[] = {
+    /*  0            1               2                 3                  4             5                  6                    7                     */
+    /*  8            9               A                 B                  C             D                  E                    F                     */
+    SDLK_UNKNOWN,    SDLK_ESCAPE,    SDLK_1,           SDLK_2,            SDLK_3,       SDLK_4,            SDLK_5,              SDLK_6,          /* 0 */
+    SDLK_7,          SDLK_8,         SDLK_9,           SDLK_0,            SDLK_MINUS,   SDLK_EQUALS,       SDLK_BACKSPACE,      SDLK_TAB,        /* 0 */
+
+    SDLK_q,          SDLK_w,         SDLK_e,           SDLK_r,            SDLK_t,       SDLK_y,            SDLK_u,              SDLK_i,          /* 1 */
+    SDLK_o,          SDLK_p,         SDLK_LEFTBRACKET, SDLK_RIGHTBRACKET, SDLK_RETURN,  SDLK_LCTRL,        SDLK_a,              SDLK_s,          /* 1 */
+
+    SDLK_d,          SDLK_f,         SDLK_g,           SDLK_h,            SDLK_j,       SDLK_k,            SDLK_l,              SDLK_SEMICOLON,  /* 2 */
+    SDLK_UNKNOWN,    SDLK_BACKQUOTE, SDLK_LSHIFT,      SDLK_BACKSLASH,    SDLK_z,       SDLK_x,            SDLK_c,              SDLK_v,          /* 2 */
+
+    SDLK_b,          SDLK_n,         SDLK_m,           SDLK_COMMA,        SDLK_PERIOD,  SDLK_SLASH,        SDLK_RSHIFT,         SDLK_PRINT,      /* 3 */
+    SDLK_LALT,       SDLK_SPACE,     SDLK_CAPSLOCK,    SDLK_F1,           SDLK_F2,      SDLK_F3,           SDLK_F4,             SDLK_F5,         /* 3 */
+
+    SDLK_F6,         SDLK_F7,        SDLK_F8,          SDLK_F9,           SDLK_F10,     SDLK_NUMLOCK,      SDLK_SCROLLOCK,      SDLK_HOME,       /* 4 */
+    SDLK_UP,         SDLK_PAGEUP,    SDLK_KP_MINUS,    SDLK_LEFT,         SDLK_KP5,     SDLK_RIGHT,        SDLK_KP_PLUS,        SDLK_END,        /* 4 */
+
+    SDLK_DOWN,       SDLK_PAGEDOWN,  SDLK_INSERT,      SDLK_DELETE,       SDLK_UNKNOWN, SDLK_UNKNOWN,      SDLK_UNKNOWN,        SDLK_F11,        /* 5 */
+    SDLK_F12,        SDLK_PAUSE,     SDLK_UNKNOWN,     SDLK_LSUPER,       SDLK_RSUPER,  SDLK_MODE,         SDLK_UNKNOWN,        SDLK_UNKNOWN,    /* 5 */
+
+    SDLK_UNKNOWN,    SDLK_UNKNOWN,   SDLK_UNKNOWN,     SDLK_UNKNOWN,      SDLK_F13,     SDLK_F14,          SDLK_F15,            SDLK_UNKNOWN,    /* 6 */
+    SDLK_UNKNOWN,    SDLK_UNKNOWN,   SDLK_UNKNOWN,     SDLK_UNKNOWN,      SDLK_UNKNOWN, SDLK_UNKNOWN,      SDLK_UNKNOWN,        SDLK_UNKNOWN,    /* 6 */
+
+    SDLK_WORLD_2,    SDLK_UNKNOWN,   SDLK_UNKNOWN,     SDLK_WORLD_1,      SDLK_UNKNOWN, SDLK_UNKNOWN,      SDLK_UNKNOWN,        SDLK_UNKNOWN,    /* 7 */
+    SDLK_UNKNOWN,    SDLK_WORLD_4,   SDLK_UNKNOWN,     SDLK_WORLD_5,      SDLK_UNKNOWN, SDLK_WORLD_3,      SDLK_UNKNOWN,        SDLK_UNKNOWN     /* 7 */
+};
+
+const SDLKey scancode_rmapping_extended[][2] = {
+    { SDLK_KP_ENTER,  SDLK_RETURN },
+    { SDLK_RALT,      SDLK_LALT },
+    { SDLK_RCTRL,     SDLK_LCTRL },
+    { SDLK_KP_DIVIDE, SDLK_SLASH },
+    //{ SDLK_KPPLUS,    SDLK_CAPSLOCK }
+};
+
+const SDLKey scancode_rmapping_nonextended[][2] = {
+    { SDLK_KP7,         SDLK_HOME },
+    { SDLK_KP8,         SDLK_UP },
+    { SDLK_KP9,         SDLK_PAGEUP },
+    { SDLK_KP4,         SDLK_LEFT },
+    { SDLK_KP6,         SDLK_RIGHT },
+    { SDLK_KP1,         SDLK_END },
+    { SDLK_KP2,         SDLK_DOWN },
+    { SDLK_KP3,         SDLK_PAGEDOWN },
+    { SDLK_KP0,         SDLK_INSERT },
+    { SDLK_KP_PERIOD,   SDLK_DELETE },
+    { SDLK_KP_MULTIPLY, SDLK_PRINT }
+};
+
+static void gfx_sdl_set_mode(void) {
+    if (configWindow.exiting_fullscreen)
+        configWindow.exiting_fullscreen = false;
+
+    if (configWindow.reset) {
+        configWindow.fullscreen = false;
+        configWindow.x = WAPI_WIN_CENTERPOS;
+        configWindow.y = WAPI_WIN_CENTERPOS;
+        configWindow.w = DESIRED_SCREEN_WIDTH;
+        configWindow.h = DESIRED_SCREEN_HEIGHT;
+        configWindow.reset = false;
+    }
+
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+
+    uint32_t flags = SDL_OPENGL;
+    if (configWindow.fullscreen)
+        flags |= SDL_FULLSCREEN;
+    else
+        flags |= SDL_RESIZABLE;
+
+    if (!SDL_VideoModeOK(configWindow.w, configWindow.h, desktop_bpp, flags)) {
+        printf(
+            "video mode [%dx%d fullscreen %d] not available, falling back to default\n",
+            configWindow.w, configWindow.h, configWindow.fullscreen
+        );
+        configWindow.w = DESIRED_SCREEN_WIDTH;
+        configWindow.h = DESIRED_SCREEN_HEIGHT;
+        configWindow.fullscreen = false;
+        flags = SDL_OPENGL | SDL_RESIZABLE;
+    }
+
+    if (!SDL_SetVideoMode(configWindow.w, configWindow.h, desktop_bpp, flags)) {
+        sys_fatal(
+            "could not set video mode [%dx%d fullscreen %d]: %s\n",
+            configWindow.w, configWindow.h, configWindow.fullscreen, SDL_GetError()
+        );
+    }
+
+    window_w = configWindow.w;
+    window_h = configWindow.h;
+}
+
+static void gfx_sdl_init(const char *window_title) {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0)
+        sys_fatal("Could not init SDL1 video: %s\n", SDL_GetError());
+
+    const SDL_VideoInfo *vinfo = SDL_GetVideoInfo();
+    desktop_w = vinfo->current_w;
+    desktop_h = vinfo->current_h;
+    desktop_bpp = vinfo->vfmt->BitsPerPixel;
+
+    SDL_WM_SetCaption(window_title, NULL);
+
+    // set actual desired video mode
+
+    gfx_sdl_set_mode();
+
+    SDL_ShowCursor(0);
+
+    for (size_t i = 0; i < sizeof(windows_scancode_table) / sizeof(SDLKey); i++) {
+        inverted_scancode_table[windows_scancode_table[i]] = i;
+    }
+
+    for (size_t i = 0; i < sizeof(scancode_rmapping_extended) / sizeof(scancode_rmapping_extended[0]); i++) {
+        inverted_scancode_table[scancode_rmapping_extended[i][0]] = inverted_scancode_table[scancode_rmapping_extended[i][1]] + 0x100;
+    }
+
+    for (size_t i = 0; i < sizeof(scancode_rmapping_nonextended) / sizeof(scancode_rmapping_nonextended[0]); i++) {
+        inverted_scancode_table[scancode_rmapping_nonextended[i][0]] = inverted_scancode_table[scancode_rmapping_nonextended[i][1]];
+        inverted_scancode_table[scancode_rmapping_nonextended[i][1]] += 0x100;
+    }
+}
+
+static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
+    run_one_game_iter();
+}
+
+static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
+    if (width) *width = window_w;
+    if (height) *height = window_h;
+}
+
+static int translate_scancode(int scancode) {
+    if (scancode < 512) {
+        return inverted_scancode_table[scancode];
+    } else {
+        return 0;
+    }
+}
+
+static void gfx_sdl_onkeydown(int scancode) {
+    if (kb_key_down)
+        kb_key_down(translate_scancode(scancode));
+}
+
+static void gfx_sdl_onkeyup(int scancode) {
+    if (kb_key_up)
+        kb_key_up(translate_scancode(scancode));
+}
+
+static void gfx_sdl_handle_events(void) {
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+        switch (event.type) {
+#ifndef TARGET_WEB
+            // Scancodes are broken in Emscripten SDL2: https://bugzilla.libsdl.org/show_bug.cgi?id=3259
+            case SDL_KEYDOWN:
+                gfx_sdl_onkeydown(event.key.keysym.sym);
+                // ALT+F4 in case the OS doesn't do it (SDL1 doesn't seem to do it on my machine)
+                if (event.key.keysym.sym == SDLK_F4 && (event.key.keysym.mod & (KMOD_LALT | KMOD_RALT)))
+                    game_exit();
+                break;
+            case SDL_KEYUP:
+                gfx_sdl_onkeyup(event.key.keysym.sym);
+                break;
+#endif
+            case SDL_VIDEORESIZE:
+                window_w = configWindow.w = event.resize.w;
+                window_h = configWindow.h = event.resize.h;
+                break;
+            case SDL_QUIT:
+                game_exit();
+                break;
+        }
+    }
+}
+
+static void gfx_sdl_set_keyboard_callbacks(kb_callback_t on_key_down, kb_callback_t on_key_up, void (*on_all_keys_up)(void)) {
+    kb_key_down = on_key_down;
+    kb_key_up = on_key_up;
+    kb_all_keys_up = on_all_keys_up;
+}
+
+static bool gfx_sdl_start_frame(void) {
+    return true;
+}
+
+static inline void sync_framerate_with_timer(void) {
+    static Uint32 last_time = 0;
+    // get base timestamp on the first frame (might be different from 0)
+    if (last_time == 0) last_time = SDL_GetTicks();
+    const int elapsed = SDL_GetTicks() - last_time;
+    if (elapsed < frame_time)
+        SDL_Delay(frame_time - elapsed);
+    last_time += frame_time;
+}
+
+static void gfx_sdl_swap_buffers_begin(void) {
+    sync_framerate_with_timer();
+    SDL_GL_SwapBuffers();
+}
+
+static void gfx_sdl_swap_buffers_end(void) {
+}
+
+static double gfx_sdl_get_time(void) {
+    return 0.0;
+}
+
+
+static void gfx_sdl_shutdown(void) {
+    if (SDL_WasInit(0))
+        SDL_Quit();
+}
+
+struct GfxWindowManagerAPI gfx_sdl = {
+    gfx_sdl_init,
+    gfx_sdl_set_keyboard_callbacks,
+    gfx_sdl_main_loop,
+    gfx_sdl_get_dimensions,
+    gfx_sdl_handle_events,
+    gfx_sdl_start_frame,
+    gfx_sdl_swap_buffers_begin,
+    gfx_sdl_swap_buffers_end,
+    gfx_sdl_get_time,
+    gfx_sdl_shutdown
+};
+
+#endif // BACKEND_WM

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -142,7 +142,7 @@ static inline void gfx_sdl_set_vsync(const bool enabled) {
     if (enabled) {
         // try to detect refresh rate
         SDL_GL_SetSwapInterval(1);
-        const int vblanks = test_vsync();
+        const int vblanks = gCLIOpts.SyncFrames ? (int)gCLIOpts.SyncFrames : test_vsync();
         if (vblanks) {
             printf("determined swap interval: %d\n", vblanks);
             SDL_GL_SetSwapInterval(vblanks);

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -347,7 +347,7 @@ static inline void sync_framerate_with_timer(void) {
         const double elapsed = last_sec ? (now - last_sec) : (now - last_time);
         if ((elapsed < frame_time && !last_sec) || (elapsed < frames_since_last_sec * frame_time && last_sec)) {
             const double delay = last_sec ? frames_since_last_sec * frame_time - elapsed : frame_time - elapsed;
-            usleep(delay / perf_freq * 1000000.0);
+            sys_sleep(delay / perf_freq * 1000000.0);
             last_time = now + delay;
         } else {
             last_time = now;

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -172,10 +172,6 @@ static void on_anim_frame(double time) {
 #endif
 
 void main_func(void) {
-    static u64 pool[0x165000/8 / 4 * sizeof(void *)];
-    main_pool_init(pool, pool + sizeof(pool) / sizeof(pool[0]));
-    gEffectsMemoryPool = mem_pool_init(0x4000, MEMORY_POOL_LEFT);
-
     const char *gamedir = gCLIOpts.GameDir[0] ? gCLIOpts.GameDir : FS_BASEDIR;
     const char *userpath = gCLIOpts.SavePath[0] ? gCLIOpts.SavePath : sys_user_path();
     fs_init(sys_ropaths, gamedir, userpath);
@@ -186,6 +182,12 @@ void main_func(void) {
         configWindow.fullscreen = true;
     else if (gCLIOpts.FullScreen == 2)
         configWindow.fullscreen = false;
+
+    const size_t poolsize = gCLIOpts.PoolSize ? gCLIOpts.PoolSize : DEFAULT_POOL_SIZE;
+    u64 *pool = malloc(poolsize);
+    if (!pool) sys_fatal("Could not alloc %u bytes for main pool.\n", poolsize);
+    main_pool_init(pool, pool + poolsize / sizeof(pool[0]));
+    gEffectsMemoryPool = mem_pool_init(0x4000, MEMORY_POOL_LEFT);
 
     #if defined(WAPI_SDL1) || defined(WAPI_SDL2)
     wm_api = &gfx_sdl;

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -222,8 +222,10 @@ void main_func(void) {
     gfx_init(wm_api, rendering_api, window_title);
     wm_api->set_keyboard_callbacks(keyboard_on_key_down, keyboard_on_key_up, keyboard_on_all_keys_up);
 
+    #if defined(AAPI_SDL1) || defined(AAPI_SDL2)
     if (audio_api == NULL && audio_sdl.init()) 
         audio_api = &audio_sdl;
+    #endif
 
     if (audio_api == NULL) {
         audio_api = &audio_null;

--- a/text/us/dialogs.h
+++ b/text/us/dialogs.h
@@ -1982,7 +1982,7 @@ Enjoy!!!"
 
 DEFINE_DIALOG(DIALOG_161, 1, 4, 30, 200, _("\
 Mario!!!\n\
-It that really you???\n\
+Is that really you???\n\
 It has been so long since\n\
 our last adventure!\n\
 They told me that I might\n\

--- a/tools/n64graphics_ci_dir/exoquant/exoquant.c
+++ b/tools/n64graphics_ci_dir/exoquant/exoquant.c
@@ -24,7 +24,9 @@ SOFTWARE.
 
 #include "exoquant.h"
 
-#ifndef OSX_BUILD // OSX build cannot have malloc defined
+#ifdef __APPLE__
+// No malloc on mac
+#else
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
This adds a new setting to the Display menu that lets you change the draw distance to anywhere between 0.5x and 5x the original game's draw distance, in 10% increments. This should be useful for weaker devices like a Raspberry Pi that can't handle the NODRAWINGDISTANCE build option. This option does not appear in the menu if NODRAWINGDISTANCE is used.

This was implemented by adding a new variable that is multiplied with every instance where an object's distance to Mario is compared in an "#ifndef NODRAWINGDISTANCE" define. Additionally, all of the original draw distances are divided by 100 since 100 represents a normal draw distance. The end result is the same, but this removes the need for continuous float multiplication where applicable (example: "2400.0f" becomes "24 * configDrawDistance", where configDrawDistance is an integer between 50 and 500, default=100).

[Draw Distance Setting.zip](https://github.com/GateGuy/sm64pc/files/5798206/Draw.Distance.Setting.zip)

(Note: Ignore the "Files changed" section and instead look at the "Files changed" in the [pull request](https://github.com/sm64pc/sm64ex/pull/446) on the main repo. In the PR that you're currently reading, there are many changes that are not part of this patch; they may have been mixed in because I made this using an outdated nightly. The patch does still work on current nightlies, however, and the redundant changes are not included in the patch itself.)